### PR TITLE
refactor: convert simulation helper to esm imports

### DIFF
--- a/test/helpers/simulation.js
+++ b/test/helpers/simulation.js
@@ -1,9 +1,9 @@
-import fs from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import vm from 'node:vm';
-import { fileURLToPath } from 'node:url';
+import fs from 'fs';
+import path from 'path';
+import vm from 'vm';
+import { fileURLToPath } from 'url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function loadSimulation(extra = {}) {
   const sandbox = {
@@ -18,8 +18,8 @@ function loadSimulation(extra = {}) {
     },
     ...extra
   };
-  const streamCode = fs.readFileSync(resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
+  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
+  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
   vm.runInNewContext(streamCode, sandbox);
   vm.runInNewContext(simulationCode, sandbox);
   return sandbox;


### PR DESCRIPTION
## Summary
- migrate simulation helper to use ES module imports and `import.meta.url`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc668a53e88328984998e4863072fe