### PR TITLE
refactor: use esm exports for core services

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -3,6 +3,9 @@ import './components/raciMatrix.js';
 import { logUser, currentUser, authMenuOption } from './auth.js';
 import { initAddOnOverlays } from './addOnOverlays.js';
 import { initAddOnFiltering } from './addOnFiltering.js';
+import { Stream } from './core/stream.js';
+import { createSimulation } from './core/simulation.js';
+import { currentTheme, applyThemeToPage } from './core/theme.js';
 import BpmnSnapping from 'bpmn-js/lib/features/snapping';
 import AttachBoundaryModule from '../features/attach-boundary/index.js';
 

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,3 +1,5 @@
+import { Stream } from './core/stream.js';
+
 export const logUser = new Stream('👤 Login');
 export let currentUser = null;
 window.currentUser = currentUser;

--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -1,5 +1,7 @@
 // public/js/core/simulation.js
 
+import { Stream } from './stream.js';
+
 // Simple token simulation service built on Streams
 // Usage:
 //   const simulation = createSimulation({ elementRegistry, canvas, context: { foo: true } }, { delay: 500 });
@@ -13,7 +15,7 @@
 //     return [token];
 //   });
 
-function createSimulation(services, opts = {}) {
+export function createSimulation(services, opts = {}) {
   const { elementRegistry, canvas, context: initialContext = {} } = services;
   const delay = opts.delay || 1000;
   const conditionFallback = Object.prototype.hasOwnProperty.call(opts, 'conditionFallback')

--- a/public/js/core/stream.js
+++ b/public/js/core/stream.js
@@ -1,4 +1,4 @@
-class Stream {
+export class Stream {
   constructor(initial) {
     this.subscribers = [];
 
@@ -39,7 +39,7 @@ class Stream {
 }
 
 // === Helper: derived stream ===
-function derived(streams, transformFn, options = {}) {
+export function derived(streams, transformFn, options = {}) {
   const isArray = Array.isArray(streams);
   const sources = isArray ? streams : [streams];
   const getValues = () => isArray ? streams.map(s => s.get()) : [streams.get()];
@@ -84,7 +84,7 @@ function derived(streams, transformFn, options = {}) {
 
 
 
-function fieldStream(sourceStream, fieldName) {
+export function fieldStream(sourceStream, fieldName) {
   const derived = new Stream(sourceStream.get()?.[fieldName] ?? '');
   sourceStream.subscribe(value => {
     derived.set(value?.[fieldName] ?? '');
@@ -101,7 +101,7 @@ function fieldStream(sourceStream, fieldName) {
  * const unsub = tickStream.subscribe(value => { // handle value });
  * // later: stop(); unsub();
  */
-function intervalStream(ms, fn) {
+export function intervalStream(ms, fn) {
   const stream = new Stream();
   const id = setInterval(() => stream.set(fn()), ms);
   const cleanup = () => clearInterval(id);
@@ -117,14 +117,14 @@ function intervalStream(ms, fn) {
  * doneStream.subscribe(value => { // handle completion });
  * // later: cancel();
  */
-function timeoutStream(ms, value) {
+export function timeoutStream(ms, value) {
   const stream = new Stream();
   const id = setTimeout(() => stream.set(value), ms);
   const cleanup = () => clearTimeout(id);
   return [stream, cleanup];
 }
 
-function observeDOMRemoval(el, ...cleanups) {
+export function observeDOMRemoval(el, ...cleanups) {
   const observer = new MutationObserver(() => {
     if (!document.body.contains(el)) {
       cleanups.forEach(fn => fn?.());
@@ -132,5 +132,9 @@ function observeDOMRemoval(el, ...cleanups) {
     }
   });
   observer.observe(document.body, { childList: true, subtree: true });
+}
+
+if (typeof window !== 'undefined') {
+  window.Stream = Stream;
 }
 

--- a/public/js/core/theme.js
+++ b/public/js/core/theme.js
@@ -1,9 +1,10 @@
 // theme.js
 
+import { Stream } from './stream.js';
+
 let themes = {};
 
-const currentTheme = new Stream({ colors: {}, fonts: {} });
-window.currentTheme = currentTheme;
+export const currentTheme = new Stream({ colors: {}, fonts: {} });
 
 function validateThemes(data) {
   const valid = {};
@@ -26,7 +27,7 @@ function validateThemes(data) {
   return valid;
 }
 
-const themesLoaded = fetch('./js/core/themes.json')
+export const themesLoaded = fetch('./js/core/themes.json')
   .then(r => r.json())
   .then(json => {
     themes = validateThemes(json);
@@ -41,9 +42,7 @@ const themesLoaded = fetch('./js/core/themes.json')
     console.error('Failed to load themes.json', err);
   });
 
-window.themesLoaded = themesLoaded;
-
-function applyTheme(el, options = {}) {
+export function applyTheme(el, options = {}) {
   const {
     size = '1rem',
     weight = 'normal',
@@ -72,7 +71,7 @@ function applyTheme(el, options = {}) {
   });
 }
 
-function themeToggleButton() {
+export function themeToggleButton() {
   const button = document.createElement('button');
   button.textContent = '🌗 Toggle Theme';
 
@@ -92,7 +91,7 @@ function themeToggleButton() {
   return button;
 }
 
-function themedThemeSelector(themeStream = currentTheme) {
+export function themedThemeSelector(themeStream = currentTheme) {
   const container = document.createElement('div');
   container.style.display = 'flex';
   container.style.alignItems = 'center';
@@ -154,7 +153,7 @@ function themedThemeSelector(themeStream = currentTheme) {
   return container;
 }
 
-function applyThemeToPage(theme, container = document.body) {
+export function applyThemeToPage(theme, container = document.body) {
   const colors = theme.colors || {};
   const fonts = theme.fonts || {};
 

--- a/test/helpers/simulation.js
+++ b/test/helpers/simulation.js
@@ -1,9 +1,5 @@
-import fs from 'fs';
-import path from 'path';
-import vm from 'vm';
-import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { Stream } from '../../public/js/core/stream.js';
+import { createSimulation } from '../../public/js/core/simulation.js';
 
 function loadSimulation(extra = {}) {
   const sandbox = {
@@ -16,17 +12,16 @@ function loadSimulation(extra = {}) {
       setItem(key, val) { this._data[key] = String(val); },
       removeItem(key) { delete this._data[key]; }
     },
+    Stream,
+    createSimulation,
     ...extra
   };
-  const streamCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(path.resolve(__dirname, '../../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
   return sandbox;
 }
 
 function createSimulationInstance(elements, opts = {}, sandbox, context) {
   const env = sandbox || loadSimulation();
+  global.localStorage = env.localStorage;
   const map = new Map(elements.map(e => [e.id, e]));
   const elementRegistry = {
     get(id) { return map.get(id); },

--- a/test/inclusive-gateway.test.js
+++ b/test/inclusive-gateway.test.js
@@ -1,46 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import vm from 'node:vm';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function loadSimulation() {
-  const sandbox = {
-    console,
-    setTimeout,
-    clearTimeout,
-    localStorage: {
-      _data: {},
-      getItem(key) { return this._data[key] || null; },
-      setItem(key, val) { this._data[key] = String(val); },
-      removeItem(key) { delete this._data[key]; }
-    }
-  };
-  const streamCode = fs.readFileSync(resolve(__dirname, '../public/js/core/stream.js'), 'utf8');
-  const simulationCode = fs.readFileSync(resolve(__dirname, '../public/js/core/simulation.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext(simulationCode, sandbox);
-  return sandbox.createSimulation;
-}
-
-function createSimulationInstance(elements, opts = {}) {
-  const map = new Map(elements.map(e => [e.id, e]));
-  const elementRegistry = {
-    get(id) { return map.get(id); },
-    filter(fn) { return Array.from(map.values()).filter(fn); }
-  };
-  for (const el of map.values()) {
-    if (!el.type && el.source && el.target) {
-      el.type = 'bpmn:SequenceFlow';
-    }
-  }
-  const canvas = { addMarker() {}, removeMarker() {} };
-  const createSimulation = loadSimulation();
-  return createSimulation({ elementRegistry, canvas }, opts);
-}
+import { createSimulationInstance } from './helpers/simulation.js';
 
 function buildDiagram(direction, outgoingCount = 1) {
   const task = { id: 'task', type: 'bpmn:Task', incoming: [], outgoing: [] };

--- a/test/simulation/exclusive-gateway-choice.test.js
+++ b/test/simulation/exclusive-gateway-choice.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import vm from 'node:vm';
 import { createSimulationInstance } from '../helpers/simulation.js';
+import { Stream } from '../../public/js/core/stream.js';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -155,11 +156,11 @@ function loadElements() {
     Node: Element,
     console,
     setTimeout,
-    clearTimeout
+    clearTimeout,
+    Stream
   };
-  const streamCode = fs.readFileSync(resolve(__dirname, '../../public/js/core/stream.js'), 'utf8');
-  vm.runInNewContext(streamCode, sandbox);
-  vm.runInNewContext('currentTheme = new Stream({ colors: {}, fonts: {} });', sandbox);
+  sandbox.window.Stream = Stream;
+  sandbox.currentTheme = new Stream({ colors: {}, fonts: {} });
   const elementsCode = fs.readFileSync(resolve(__dirname, '../../public/js/components/elements.js'), 'utf8');
   vm.runInNewContext(elementsCode, sandbox);
   return { sandbox, document };


### PR DESCRIPTION
## Summary
- export Stream class and helpers from `core/stream.js`
- convert simulation and theme modules to ESM and export their APIs
- update app/auth modules and tests to import new exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc675292108328aae71154c1978137