### PR TITLE
refactor: convert components to esm

### DIFF
--- a/public/js/addOnFiltering.js
+++ b/public/js/addOnFiltering.js
@@ -1,5 +1,7 @@
+import { createAddOnFilterPanel, selectedType, selectedSubtype } from './components/addOnFilter.js';
+import { createAddOnLegend } from './components/addOnLegend.js';
+
 export function initAddOnFiltering({ currentTheme, elementRegistry, modeling, canvas, scheduleOverlayUpdate, addOnStore, diagramXMLStream, typeIcons }) {
-  const { createAddOnFilterPanel, selectedType, selectedSubtype } = window.addOnFilter;
   let addOnFilterPanelEl = null;
 
   const filterToggleBtn = document.createElement('button');
@@ -19,11 +21,9 @@ export function initAddOnFiltering({ currentTheme, elementRegistry, modeling, ca
     addOnFilterPanelEl.style.display = isVisible ? 'none' : 'flex';
   });
 
-  if (window.addOnLegend) {
-    const legendEl = addOnLegend.createAddOnLegend(typeIcons, currentTheme);
-    legendEl.prepend(filterToggleBtn);
-    document.body.appendChild(legendEl);
-  }
+  const legendEl = createAddOnLegend(typeIcons, currentTheme);
+  legendEl.prepend(filterToggleBtn);
+  document.body.appendChild(legendEl);
 
   const highlightedNodes = new Set();
   function updateHighlightedNodes() {

--- a/public/js/components/addOnFilter.js
+++ b/public/js/components/addOnFilter.js
@@ -1,5 +1,7 @@
-(function(global){
-  const addOnTypes = {
+import { Stream } from '../core/stream.js';
+import { currentTheme } from '../core/theme.js';
+
+const addOnTypes = {
     'Knowledge': [
       'Process Assumptions',
       'Process Issues',
@@ -99,9 +101,9 @@
     ]
   };
 
-  const selectedType = new Stream(null);
-  const selectedSubtype = new Stream(null);
-  const expandedType = new Stream(null);
+const selectedType = new Stream(null);
+const selectedSubtype = new Stream(null);
+const expandedType = new Stream(null);
 
   function adjustColor(hex, amount) {
     const col = hex.startsWith('#') ? hex.slice(1) : hex;
@@ -126,7 +128,7 @@
     return adjustColor(col, brightness < 128 ? amount : -amount);
   }
 
-  function createAddOnFilterPanel(themeStream = currentTheme){
+export function createAddOnFilterPanel(themeStream = currentTheme){
     const panel = document.createElement('div');
     panel.classList.add('addon-filter');
     Object.assign(panel.style, {
@@ -213,10 +215,4 @@
     return panel;
   }
 
-  global.addOnFilter = {
-    createAddOnFilterPanel,
-    selectedType,
-    selectedSubtype
-  };
-
-})(window);
+export { selectedType, selectedSubtype };

--- a/public/js/components/addOnLegend.js
+++ b/public/js/components/addOnLegend.js
@@ -1,5 +1,7 @@
-(function(global){
-  function createAddOnLegend(typeIcons = {}, themeStream = currentTheme){
+import { Stream } from '../core/stream.js';
+import { currentTheme } from '../core/theme.js';
+
+export function createAddOnLegend(typeIcons = {}, themeStream = currentTheme){
     const container = document.createElement('div');
     Object.assign(container.style, {
       position: 'absolute',
@@ -34,8 +36,8 @@
 
     function computeCounts(){
       const counts = {};
-      if(!global.addOnStore || !addOnStore.getAllAddOns) return counts;
-      const all = addOnStore.getAllAddOns();
+      if(!window.addOnStore || !window.addOnStore.getAllAddOns) return counts;
+      const all = window.addOnStore.getAllAddOns();
       Object.values(all).forEach(addOns => {
         const seen = new Set();
         (addOns || []).forEach(a => {
@@ -55,14 +57,14 @@
       });
     });
 
-    if(global.addOnStore){
-      const originalSet = addOnStore.setAddOns;
-      addOnStore.setAddOns = function(nodeId, addOns){
+    if(window.addOnStore){
+      const originalSet = window.addOnStore.setAddOns;
+      window.addOnStore.setAddOns = function(nodeId, addOns){
         originalSet(nodeId, addOns);
         countsStream.set(computeCounts());
       };
-      const originalClear = addOnStore.clear;
-      addOnStore.clear = function(){
+      const originalClear = window.addOnStore.clear;
+      window.addOnStore.clear = function(){
         originalClear();
         countsStream.set(computeCounts());
       };
@@ -77,6 +79,3 @@
 
     return container;
   }
-
-  global.addOnLegend = { createAddOnLegend };
-})(window);

--- a/public/js/components/diagramTree.js
+++ b/public/js/components/diagramTree.js
@@ -1,11 +1,18 @@
-(function(global){
-  const treeStream = new Stream(null);
-  let selectedId = null;
+import { Stream } from '../core/stream.js';
 
-  function setSelectedId(id){
+export const treeStream = new Stream(null);
+let selectedId = null;
+export let onSelect = () => {};
+export let togglePanel = null;
+
+export function setSelectedId(id){
     selectedId = id;
     treeStream.set(treeStream.get());
   }
+
+export function getSelectedId(){
+  return selectedId;
+}
 
   function renderNode(node){
     const li = document.createElement('li');
@@ -23,7 +30,7 @@
     li.dataset.elementId = node.id;
     li.addEventListener('click', e => {
       e.stopPropagation();
-      global.diagramTree.onSelect?.(node.id);
+      onSelect?.(node.id);
     });
 
     if (node.id === selectedId){
@@ -42,7 +49,7 @@
     return li;
   }
 
-  function createTreeContainer(){
+export function createTreeContainer(){
     const container = document.createElement('div');
     treeStream.subscribe(tree => {
       container.innerHTML = '';
@@ -54,11 +61,11 @@
     return container;
   }
 
-  global.diagramTree = {
-    treeStream,
-    createTreeContainer,
-    onSelect: () => {},
-    setSelectedId,
-    get selectedId(){ return selectedId; }
-  };
-})(window);
+
+export function setOnSelect(fn){
+  onSelect = fn;
+}
+
+export function setTogglePanel(fn){
+  togglePanel = fn;
+}

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -1,8 +1,11 @@
-function text(str) {
+import { Stream, observeDOMRemoval } from '../core/stream.js';
+import { currentTheme, applyTheme } from '../core/theme.js';
+
+export function text(str) {
   return document.createTextNode(str);
 }
 
-function reactiveElement(stream, renderFn = v => v) {
+export function reactiveElement(stream, renderFn = v => v) {
   const placeholder = document.createElement('div');
 
   function update(value) {
@@ -34,7 +37,7 @@ function reactiveElement(stream, renderFn = v => v) {
 }
 
 
-function reactiveText(stream, options = {}, themeStream = currentTheme) {
+export function reactiveText(stream, options = {}, themeStream = currentTheme) {
   const el = document.createElement(options.tag || 'p');
 
   function applyStyles(theme) {
@@ -68,7 +71,7 @@ function reactiveText(stream, options = {}, themeStream = currentTheme) {
   return el;
 }
 
-function editText(stream, options = {}, themeStream = currentTheme) {
+export function editText(stream, options = {}, themeStream = currentTheme) {
   const input = document.createElement('input');
   input.type = 'text';
   input.value = stream.get();
@@ -116,7 +119,7 @@ function editText(stream, options = {}, themeStream = currentTheme) {
   return input;
 }
 
-function reactiveImage(stream, options = {}, themeStream = currentTheme) {
+export function reactiveImage(stream, options = {}, themeStream = currentTheme) {
   const img = document.createElement('img');
 
   function applyStyles(theme) {
@@ -147,7 +150,7 @@ function reactiveImage(stream, options = {}, themeStream = currentTheme) {
   return img;
 }
 
-function toggleSwitch(stream, options = {}, themeStream = currentTheme) {
+export function toggleSwitch(stream, options = {}, themeStream = currentTheme) {
   const wrapper = document.createElement('div');
   wrapper.style.display = 'flex';
   wrapper.style.alignItems = 'center';
@@ -242,7 +245,7 @@ function toggleSwitch(stream, options = {}, themeStream = currentTheme) {
 }
 
 
-function reactiveButton(labelStream, onClick, options = {}, themeStream = currentTheme) {
+export function reactiveButton(labelStream, onClick, options = {}, themeStream = currentTheme) {
   const button = document.createElement('button');
   button.type = 'button';
 
@@ -355,7 +358,7 @@ function reactiveButton(labelStream, onClick, options = {}, themeStream = curren
 }
 
 
-function fileInput(stream, options = {}, themeStream = currentTheme) {
+export function fileInput(stream, options = {}, themeStream = currentTheme) {
   const input = document.createElement('input');
   input.type = 'file';
 
@@ -393,7 +396,7 @@ function fileInput(stream, options = {}, themeStream = currentTheme) {
   return input;
 }
 
-function conditional(showStream, childElementFn) {
+export function conditional(showStream, childElementFn) {
   const wrapper = document.createElement('div');
   let child = null;
 
@@ -412,7 +415,7 @@ function conditional(showStream, childElementFn) {
   return wrapper;
 }
 
-function headerContainer(titleStream) {
+export function headerContainer(titleStream) {
   return container([
     reactiveText(titleStream, {
       size: '2rem',
@@ -427,7 +430,7 @@ function headerContainer(titleStream) {
 }
 
 
-function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple = false) {
+export function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple = false) {
   const pickStream = new Stream(null);
 
   // Overlay
@@ -555,9 +558,8 @@ function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple
   return pickStream;
 }
 // Expose helper globally for external usage
-window.openFlowSelectionModal = openFlowSelectionModal;
 
-function gridView(dataStream, options = {}, themeStream = currentTheme) {
+export function gridView(dataStream, options = {}, themeStream = currentTheme) {
   const wrapper = document.createElement('div');
   wrapper.style.overflowX = 'auto';
   wrapper.style.width = '100%';
@@ -636,7 +638,7 @@ function gridView(dataStream, options = {}, themeStream = currentTheme) {
   return wrapper;
 }
 
-function editableDropdown(valueStream, optionsStream, themeStream = currentTheme) {
+export function editableDropdown(valueStream, optionsStream, themeStream = currentTheme) {
   const wrapper = document.createElement('div');
   const select = document.createElement('select');
   const input = document.createElement('input');
@@ -817,7 +819,7 @@ async function showFileHistoryModal(filename, themeStream = currentTheme) {
   }
 }
 
-function dropdownStream(stream, selectOptions = [], themeStream = currentTheme) {
+export function dropdownStream(stream, selectOptions = [], themeStream = currentTheme) {
   const select = document.createElement('select');
 
   function applyStyles(theme) {
@@ -878,7 +880,7 @@ function dropdownStream(stream, selectOptions = [], themeStream = currentTheme) 
   return select;
 }
 
-function avatarImage(stream, options = {}, themeStream = currentTheme) {
+export function avatarImage(stream, options = {}, themeStream = currentTheme) {
   // Create the img element
   const img = document.createElement('img');
 
@@ -915,7 +917,7 @@ function avatarImage(stream, options = {}, themeStream = currentTheme) {
   return img; // Return the img element
 }
 
-function avatarDropdown(stream, options = {}, themeStream = currentTheme, menuItems = []) {
+export function avatarDropdown(stream, options = {}, themeStream = currentTheme, menuItems = []) {
   const container = document.createElement('div');
   container.style.position = 'relative';
   container.style.display = 'inline-block';
@@ -1026,7 +1028,7 @@ function avatarDropdown(stream, options = {}, themeStream = currentTheme, menuIt
 }
 
 
-function showConfirmationDialog(message, themeStream = currentTheme) {
+export function showConfirmationDialog(message, themeStream = currentTheme) {
   return new Promise((resolve) => {
     // Create modal container
     const modal = document.createElement('div');
@@ -1142,7 +1144,7 @@ function showConfirmationDialog(message, themeStream = currentTheme) {
 }
 
 
-function showToast(message, {
+export function showToast(message, {
   duration = 3000,
   themeStream = currentTheme,
   type = 'info' // 'info' | 'success' | 'warning' | 'error'
@@ -1207,7 +1209,7 @@ function showToast(message, {
 }
 
 
-function createDiagramOverlay(nameStream, versionStream, themeStream) {
+export function createDiagramOverlay(nameStream, versionStream, themeStream) {
   const overlay = document.createElement('div');
   overlay.className = 'diagram-overlay';
 

--- a/public/js/components/layout.js
+++ b/public/js/components/layout.js
@@ -1,4 +1,7 @@
-function column(children = [], options = {}, themeStream = currentTheme) {
+import { currentTheme } from '../core/theme.js';
+import { createTreeContainer, setTogglePanel } from './diagramTree.js';
+
+export function column(children = [], options = {}, themeStream = currentTheme) {
   const el = document.createElement('div');
   el.style.display = 'flex';
   el.style.flexDirection = 'column';
@@ -23,7 +26,7 @@ function column(children = [], options = {}, themeStream = currentTheme) {
   return el;
 }
 
-function row(children = [], options = {}, themeStream = currentTheme) {
+export function row(children = [], options = {}, themeStream = currentTheme) {
   const el = column(children, { ...options, direction: 'row' }, themeStream);
 
   // ensure it's a flex container
@@ -37,7 +40,7 @@ function row(children = [], options = {}, themeStream = currentTheme) {
 }
 
 
-function container(child, options = {}, themeStream = currentTheme) {
+export function container(child, options = {}, themeStream = currentTheme) {
   const div = document.createElement('div');
 
   if (Array.isArray(child)) {
@@ -64,7 +67,7 @@ function container(child, options = {}, themeStream = currentTheme) {
 }
 
 // ➖ Divider: Horizontal or vertical line
-function divider(options = {}, themeStream = currentTheme) {
+export function divider(options = {}, themeStream = currentTheme) {
   const el = document.createElement('div');
 
   const isVertical = options.vertical || false;
@@ -81,8 +84,6 @@ function divider(options = {}, themeStream = currentTheme) {
 
 // Diagram tree side panel toggle
 window.addEventListener('DOMContentLoaded', () => {
-  if (!window.diagramTree) return;
-
   const panel = document.createElement('div');
   panel.classList.add('diagram-tree-panel');
 
@@ -94,14 +95,14 @@ window.addEventListener('DOMContentLoaded', () => {
   });
   panel.appendChild(closeBtn);
 
-  const content = window.diagramTree.createTreeContainer();
+  const content = createTreeContainer();
   panel.appendChild(content);
   document.body.appendChild(panel);
 
-  window.diagramTree.togglePanel = () => {
+  setTogglePanel(() => {
     const open = panel.style.left === '0px';
     panel.style.left = open ? '-300px' : '0px';
-  };
+  });
 
   // Apply theme styling
   currentTheme.subscribe(theme => {

--- a/public/js/components/modal.js
+++ b/public/js/components/modal.js
@@ -1,5 +1,6 @@
-(function(global) {
-  function createModal(themeStream = currentTheme, onClose = () => {}) {
+import { currentTheme } from '../core/theme.js';
+
+export function createModal(themeStream = currentTheme, onClose = () => {}) {
     const theme = themeStream.get ? themeStream.get() : themeStream;
     const colors = theme.colors || {};
 
@@ -43,7 +44,4 @@
 
     return { modal, content };
   }
-
-  global.createModal = createModal;
-})(window);
 

--- a/public/js/components/raciMatrix.js
+++ b/public/js/components/raciMatrix.js
@@ -1,10 +1,9 @@
-(function(global) {
-  /**
-   * Collect RACI data from all BPMN elements in the modeler.
-   * @param {BpmnJS} modeler
-   * @returns {Array<{id:string,name:string,responsible:string,accountable:string,consulted:string,informed:string}>}
-   */
-  function collectData(modeler) {
+/**
+ * Collect RACI data from all BPMN elements in the modeler.
+ * @param {BpmnJS} modeler
+ * @returns {Array<{id:string,name:string,responsible:string,accountable:string,consulted:string,informed:string}>}
+ */
+export function collectData(modeler) {
     if (!modeler) return [];
     const elementRegistry = modeler.get('elementRegistry');
     if (!elementRegistry) return [];
@@ -25,14 +24,14 @@
           informed:   bo.informed   || raci?.informed   || attrs.informed   || ''
         };
       });
-  }
+}
 
-  /**
-   * Create a DOM node containing a RACI matrix table.
-   * @param {BpmnJS} modeler
-   * @returns {HTMLElement} DOM node for mounting
-   */
-  function createRaciMatrix(modeler) {
+/**
+ * Create a DOM node containing a RACI matrix table.
+ * @param {BpmnJS} modeler
+ * @returns {HTMLElement} DOM node for mounting
+ */
+export function createRaciMatrix(modeler) {
     const data = collectData(modeler);
 
     const table = document.createElement('table');
@@ -117,9 +116,4 @@
 
     return container;
   }
-
-  global.raciMatrix = {
-    createRaciMatrix
-  };
-})(window);
 

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -1,3 +1,8 @@
+import { Stream } from '../core/stream.js';
+import { currentTheme } from '../core/theme.js';
+import { reactiveButton, showConfirmationDialog } from './elements.js';
+import { divider } from './layout.js';
+
 // 1) Create the sidebar container (hidden by default)
 const propsSidebar = document.createElement('div');
 propsSidebar.classList.add('props-sidebar');
@@ -292,7 +297,7 @@ function openUrlModal(url) {
   document.body.appendChild(modal);
 }
 
-function showProperties(element, modeling, moddle) {
+export function showProperties(element, modeling, moddle) {
   const bo = element.businessObject;
   const type = element.businessObject.$type;
   const fieldKeys = BPMN_PROPERTY_MAP[type] || [];
@@ -346,14 +351,14 @@ function showProperties(element, modeling, moddle) {
 
   // Sync store on open
   if (window.addOnStore) {
-    addOnStore.setAddOns(bo.id, currentAddOns);
+    window.addOnStore.setAddOns(bo.id, currentAddOns);
   }
 
   // Attach button
   const attachBtn = reactiveButton(
     new Stream("Attach AddOn"),
     () => {
-      openAddOnChooserModal(currentTheme).subscribe(selectedAddOn => {
+      window.openAddOnChooserModal(currentTheme).subscribe(selectedAddOn => {
         if (!selectedAddOn) return;
 
         const newEntry = {
@@ -373,7 +378,7 @@ function showProperties(element, modeling, moddle) {
 
         // Sync store after add
         if (window.addOnStore) {
-          addOnStore.setAddOns(bo.id, currentAddOns);
+          window.addOnStore.setAddOns(bo.id, currentAddOns);
         }
 
       });
@@ -487,7 +492,7 @@ function showProperties(element, modeling, moddle) {
 
           // Sync store after remove
           if (window.addOnStore) {
-            addOnStore.setAddOns(bo.id, currentAddOns);
+            window.addOnStore.setAddOns(bo.id, currentAddOns);
           }
         }
       },
@@ -523,7 +528,7 @@ function showProperties(element, modeling, moddle) {
         currentAddOns = parsedAddOns;
         addOnsField.value = JSON.stringify(currentAddOns, null, 2);
         if (window.addOnStore) {
-          addOnStore.setAddOns(bo.id, currentAddOns);
+          window.addOnStore.setAddOns(bo.id, currentAddOns);
         }
       } catch (e) {
         alert('AddOns must be valid JSON');
@@ -918,7 +923,7 @@ function getOrCreateExtEl(bo, moddle) {
 
       
   // hide helper cleans up subscription
-  function hideSidebar() {
+export function hideSidebar() {
     propsSidebar.classList.remove('open');
     propsSidebar.style.display = 'none';
     if (propsSidebar._unsubTheme) {

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -1,5 +1,7 @@
-(function(global){
-  function createTokenListPanel(logStream, themeStream = currentTheme){
+import { currentTheme } from '../core/theme.js';
+import { observeDOMRemoval } from '../core/stream.js';
+
+export function createTokenListPanel(logStream, themeStream = currentTheme){
     const panel = document.createElement('div');
     panel.classList.add('token-list-panel');
     panel.setAttribute('aria-hidden', 'true');
@@ -141,11 +143,11 @@
     }
 
     clearBtn.addEventListener('click', () => {
-      if (global.simulation && typeof global.simulation.clearTokenLog === 'function') {
-        global.simulation.clearTokenLog();
+      if (window.simulation && typeof window.simulation.clearTokenLog === 'function') {
+        window.simulation.clearTokenLog();
       }
-      if (global.blockchain && typeof global.blockchain.reset === 'function') {
-        global.blockchain.reset();
+      if (window.blockchain && typeof window.blockchain.reset === 'function') {
+        window.blockchain.reset();
       }
     });
 
@@ -155,6 +157,3 @@
 
     return { el: panel, show, hide, showDownload, setDownloadHandler, setTreeButton };
   }
-
-  global.tokenListPanel = { createTokenListPanel };
-})(window);

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,3 +1,8 @@
+import { Stream } from './core/stream.js';
+import { currentTheme } from './core/theme.js';
+import { createModal } from './components/modal.js';
+import { editText, reactiveButton, dropdownStream, showConfirmationDialog } from './components/elements.js';
+
 const db = firebase.firestore();
 
 // Inject responsive modal styles
@@ -887,7 +892,7 @@ function truncate(str, length = 40) {
   return str.length > length ? str.slice(0, length) + '...' : str;
 }
 
-function openAddOnChooserModal(themeStream = currentTheme) {
+export function openAddOnChooserModal(themeStream = currentTheme) {
 
   refreshAddOns();
   const modalStream = new Stream(null);
@@ -1198,3 +1203,5 @@ function openAddOnHistoryModal(addOnId, themeStream = currentTheme) {
     }
   });
 }
+
+window.openAddOnChooserModal = openAddOnChooserModal;

--- a/test/raci-matrix.test.js
+++ b/test/raci-matrix.test.js
@@ -1,21 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import fs from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import vm from 'node:vm';
 import BpmnModdle from 'bpmn-moddle';
 import customModdle from '../public/js/custom-moddle.json' assert { type: 'json' };
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-function loadCollectData() {
-  const file = fs.readFileSync(resolve(__dirname, '../public/js/components/raciMatrix.js'), 'utf8');
-  const patched = file.replace('global.raciMatrix = {', 'global.raciMatrix = { collectData,');
-  const sandbox = { window: {} };
-  vm.runInNewContext(patched, sandbox);
-  return sandbox.window.raciMatrix.collectData;
-}
+import { collectData } from '../public/js/components/raciMatrix.js';
 
 test('collectData extracts RACI values from task', async () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -47,7 +34,6 @@ test('collectData extracts RACI values from task', async () => {
     }
   };
 
-  const collectData = loadCollectData();
   const rows = collectData(modeler);
   assert.strictEqual(rows.length, 1);
   const row = rows[0];


### PR DESCRIPTION
## Summary
- refactor component scripts into ES modules with explicit exports
- replace global access with direct imports throughout app and tests
- update tests to import module APIs directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc77cb3a50832892ca08eaa645d84e