### PR TITLE
Consolidate script loading into single ESM entry

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -176,23 +176,9 @@
   <!-- DOMPurify for sanitizing HTML -->
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.min.js"></script>
 
-  <!-- 5) Your Jazira core -->
-  <script src="js/core/stream.js"></script>
-  <script src="js/core/theme.js"></script>
-  <script src="js/core/simulation.js"></script>
-  <script src="js/components/elements.js"></script>
-  <script src="js/components/layout.js"></script>
-  <script src="js/components/modal.js"></script>
-  <script src="js/components/diagramTree.js"></script>
-  <script src="js/components/showProperties.js"></script>
-  <script src="js/components/addOnFilter.js"></script>
-    <script src="js/components/addOnLegend.js"></script>
-    <script src="js/components/tokenListPanel.js"></script>
+  <!-- Utility libraries -->
   <script src="https://cdn.jsdelivr.net/npm/js-sha256@0.11.0/build/sha256.min.js"></script>
-  <script src="js/blockchain.js"></script>
-  <!-- 6) Your application code -->
-  <script src="js/firebase.js"></script>
-  <script src="js/addOnStore.js"></script>
+
   <script type="importmap">
   {
     "imports": {
@@ -218,8 +204,6 @@
   }
   </script>
   <script type="module" src="js/app.js"></script>
-  <script src="js/login.js"></script>
-  <script src="js/palette-toggle.js"></script>
   <!-- 7) more to come -->
 
 </body>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -13,6 +13,14 @@ import { currentTheme, applyThemeToPage } from './core/theme.js';
 import BpmnSnapping from 'bpmn-js/lib/features/snapping';
 import AttachBoundaryModule from '../features/attach-boundary/index.js';
 import { Blockchain } from './blockchain.js';
+import './addOnStore.js';
+import './palette-toggle.js';
+import './components/layout.js';
+
+await import('./firebase.js').catch(() => console.warn('firebase.js not found; skipping Firebase initialization.'));
+await import('./login.js').catch(() => console.warn('login.js failed to load.'));
+
+const { addOnStore } = window;
 
 // js/app.js
   const typeIcons = {


### PR DESCRIPTION
## Summary
- Remove numerous legacy script tags from `index.html` and use a single `<script type="module" src="js/app.js">` entry.
- Import ESM modules directly in `app.js`, including login, palette toggle, layout, and add-on store.
- Dynamically load optional Firebase configuration and login modules to preserve runtime flexibility.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c1380a883289a3390f53c7a6995