### PR TITLE
refactor: import globals and remove window lookups

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -260,12 +260,11 @@ Object.assign(document.body.style, {
   let blockchain;
   let processedTokens = 0;
   let blockchainPersistPromise = Promise.resolve();
-  window.blockchain = blockchain;
 
   function initBlockchain() {
     tokenPanel.hide();
     blockchain = new Blockchain();
-    window.blockchain = blockchain;
+    tokenPanel.setBlockchain(blockchain);
     processedTokens = 0;
   }
 

--- a/public/js/components/tokenListPanel.js
+++ b/public/js/components/tokenListPanel.js
@@ -40,6 +40,7 @@ export function createTokenListPanel(logStream, themeStream = currentTheme){
     panel.appendChild(list);
 
     let prevLength = 0;
+    let blockchain = null;
 
     function getTypeClass(id){
       if(!id) return null;
@@ -142,12 +143,16 @@ export function createTokenListPanel(logStream, themeStream = currentTheme){
       downloadBtn.addEventListener('click', handler);
     }
 
+    function setBlockchain(bc){
+      blockchain = bc;
+    }
+
     clearBtn.addEventListener('click', () => {
       if (window.simulation && typeof window.simulation.clearTokenLog === 'function') {
         window.simulation.clearTokenLog();
       }
-      if (window.blockchain && typeof window.blockchain.reset === 'function') {
-        window.blockchain.reset();
+      if (blockchain && typeof blockchain.reset === 'function') {
+        blockchain.reset();
       }
     });
 
@@ -155,5 +160,5 @@ export function createTokenListPanel(logStream, themeStream = currentTheme){
 
     observeDOMRemoval(panel, ...cleanupFns);
 
-    return { el: panel, show, hide, showDownload, setDownloadHandler, setTreeButton };
+    return { el: panel, show, hide, showDownload, setDownloadHandler, setTreeButton, setBlockchain };
   }


### PR DESCRIPTION
## Summary
- inject blockchain instance into token list panel instead of reading from window
- initialize blockchain in app and pass to token panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc8143ab4883288b14d481e350a6b2