### PR TITLE
Include theme selector import in app module

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,7 +9,7 @@ import { initAddOnOverlays } from './addOnOverlays.js';
 import { initAddOnFiltering } from './addOnFiltering.js';
 import { Stream } from './core/stream.js';
 import { createSimulation } from './core/simulation.js';
-import { currentTheme, applyThemeToPage } from './core/theme.js';
+import { currentTheme, applyThemeToPage, themedThemeSelector } from './core/theme.js';
 import BpmnSnapping from 'bpmn-js/lib/features/snapping';
 import AttachBoundaryModule from '../features/attach-boundary/index.js';
 import { Blockchain } from './blockchain.js';


### PR DESCRIPTION
## Summary
- include `themedThemeSelector` in theme import so toolbar theme selector initializes correctly

## Testing
- `npm test`
- `node --check public/js/app.js`
- ⚠️ attempted to run a headless DOM using jsdom, but installation was blocked by network restrictions

------
https://chatgpt.com/codex/tasks/task_e_68bc84edfac08328ab19089834ffdad2