### PR TITLE
refactor: use named layout imports

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -15,7 +15,7 @@ import AttachBoundaryModule from '../features/attach-boundary/index.js';
 import { Blockchain } from './blockchain.js';
 import './addOnStore.js';
 import './palette-toggle.js';
-import './components/layout.js';
+import { row } from './components/layout.js';
 // Initialization function will handle dynamic imports and DOM setup later.
 
 // js/app.js

--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -1,5 +1,6 @@
 import { Stream, observeDOMRemoval } from '../core/stream.js';
 import { currentTheme, applyTheme } from '../core/theme.js';
+import { container } from './layout.js';
 
 export function text(str) {
   return document.createTextNode(str);

--- a/public/js/components/layout.js
+++ b/public/js/components/layout.js
@@ -83,36 +83,38 @@ export function divider(options = {}, themeStream = currentTheme) {
 }
 
 // Diagram tree side panel toggle
-window.addEventListener('DOMContentLoaded', () => {
-  const panel = document.createElement('div');
-  panel.classList.add('diagram-tree-panel');
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => {
+    const panel = document.createElement('div');
+    panel.classList.add('diagram-tree-panel');
 
-  const closeBtn = document.createElement('button');
-  closeBtn.textContent = '\u00D7';
-  closeBtn.classList.add('diagram-tree-close');
-  closeBtn.addEventListener('click', () => {
-    panel.style.left = '-300px';
+    const closeBtn = document.createElement('button');
+    closeBtn.textContent = '\u00D7';
+    closeBtn.classList.add('diagram-tree-close');
+    closeBtn.addEventListener('click', () => {
+      panel.style.left = '-300px';
+    });
+    panel.appendChild(closeBtn);
+
+    const content = createTreeContainer();
+    panel.appendChild(content);
+    document.body.appendChild(panel);
+
+    setTogglePanel(() => {
+      const open = panel.style.left === '0px';
+      panel.style.left = open ? '-300px' : '0px';
+    });
+
+    // Apply theme styling
+    currentTheme.subscribe(theme => {
+      const colors = theme.colors;
+      panel.style.background = colors.surface;
+      panel.style.color = colors.foreground;
+      panel.style.boxShadow = `2px 0 6px ${colors.border}`;
+
+      closeBtn.style.background = 'transparent';
+      closeBtn.style.color = colors.foreground;
+      closeBtn.style.border = 'none';
+    });
   });
-  panel.appendChild(closeBtn);
-
-  const content = createTreeContainer();
-  panel.appendChild(content);
-  document.body.appendChild(panel);
-
-  setTogglePanel(() => {
-    const open = panel.style.left === '0px';
-    panel.style.left = open ? '-300px' : '0px';
-  });
-
-  // Apply theme styling
-  currentTheme.subscribe(theme => {
-    const colors = theme.colors;
-    panel.style.background = colors.surface;
-    panel.style.color = colors.foreground;
-    panel.style.boxShadow = `2px 0 6px ${colors.border}`;
-
-    closeBtn.style.background = 'transparent';
-    closeBtn.style.color = colors.foreground;
-    closeBtn.style.border = 'none';
-  });
-});
+}

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -1,7 +1,7 @@
 import { Stream } from '../core/stream.js';
 import { currentTheme } from '../core/theme.js';
 import { reactiveButton, showConfirmationDialog } from './elements.js';
-import { divider } from './layout.js';
+import { divider, row } from './layout.js';
 
 // 1) Create the sidebar container (hidden by default)
 const propsSidebar = document.createElement('div');

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -2,6 +2,7 @@ import { Stream } from './core/stream.js';
 import { currentTheme } from './core/theme.js';
 import { createModal } from './components/modal.js';
 import { editText, reactiveButton, dropdownStream, showConfirmationDialog } from './components/elements.js';
+import { column, row } from './components/layout.js';
 
 const db = firebase.firestore();
 


### PR DESCRIPTION
## Summary
- switch layout import in app to use row helper
- expose layout helpers in login and showProperties
- add container import and guard layout DOM init for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc868a5a348328b2e097deb6379f37