### PR TITLE
refactor login modal module

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,4 +1,5 @@
 import { Stream } from './core/stream.js';
+import { reactiveLoginModal } from './login.js';
 
 export const logUser = new Stream('👤 Login');
 export let currentUser = null;
@@ -22,7 +23,7 @@ export function authMenuOption({ avatarStream, showSaveButton, currentTheme, reb
           }
         });
       } else {
-        const userStream = window.reactiveLoginModal(currentTheme);
+        const userStream = reactiveLoginModal(currentTheme);
         userStream.subscribe(result => {
           if (result instanceof Error) {
             if (window.showToast) {

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -22,7 +22,7 @@ const db = firebase.firestore();
   document.head.appendChild(style);
 })();
 
-function reactiveLoginModal(themeStream = currentTheme) {
+export function reactiveLoginModal(themeStream = currentTheme) {
   const loginStream = new Stream(null); // emits user or error or null (cancel)
   const emailStream = new Stream('');
   const passwordStream = new Stream('');


### PR DESCRIPTION
## Summary
- export reactiveLoginModal and rely on ESM import
- import reactiveLoginModal in auth logic and call directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc87c064508328923799fee0f5a93b