### PR TITLE
Add Firebase config example and update import warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 firebase-debug.log*
 firebase-debug.*.log*
+# Local Firebase credentials (copy firebase.example.js to firebase.js)
 public/js/firebase.js
+!public/js/firebase.example.js
 add ons/Orpheus-bpmn.html
 add ons/bpmn_help_guide_embeddable_html.html
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,15 @@ Flow Control Center is a browser‑based BPMN modeling and simulation client. It
    npm install
    ```
 2. **Configure Firebase**
-   Create `public/js/firebase.js` and initialize Firebase with your project credentials:
+   Copy the example configuration and fill in your Firebase project credentials:
+   ```bash
+   cp public/js/firebase.example.js public/js/firebase.js
+   ```
+   Edit `public/js/firebase.js` to replace the placeholder values and initialize Firebase with your project's settings:
    ```js
    // public/js/firebase.js
-   const firebaseConfig = { /* your config */ };
+   export const firebaseConfig = { /* your real config */ };
    firebase.initializeApp(firebaseConfig);
-   const db = firebase.firestore();
    ```
 3. **Serve the app**
    Serve the `public/` directory using your preferred static server (e.g. `npx http-server public` or `firebase serve`).

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -77,7 +77,9 @@ const defaultXml = `<?xml version="1.0" encoding="UTF-8"?>
 // === Initial BPMN XML template ===
 const diagramXMLStream = new Stream(defaultXml);
 async function init() {
-  await import('./firebase.js').catch(() => console.warn('firebase.js not found; skipping Firebase initialization.'));
+  await import('./firebase.js').catch(() =>
+    console.warn('Create public/js/firebase.js from firebase.example.js to enable Firebase.')
+  );
   await import('./login.js').catch(() => console.warn('login.js failed to load.'));
 
   const { addOnStore } = window;

--- a/public/js/firebase.example.js
+++ b/public/js/firebase.example.js
@@ -1,0 +1,7 @@
+// Copy this file to firebase.js and replace the placeholder values with your Firebase project configuration.
+export const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_PROJECT.firebaseapp.com',
+  projectId: 'YOUR_PROJECT_ID'
+  // …
+};


### PR DESCRIPTION
## Summary
- add `public/js/firebase.example.js` placeholder config
- document Firebase setup and ignore real credentials
- warn when `public/js/firebase.js` is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8905c79c8328822ed833c2dc340e