### PR TITLE
refactor: migrate firebase to es modules

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -162,16 +162,6 @@
   <!-- 4) auto-layout + navigator -->
   <script src="https://unpkg.com/bpmn-auto-layout@0.4.0/dist/bpmn-auto-layout.umd.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@bpmn-io/navigator@1.0.0/dist/bpmn-navigator.umd.js"></script>
-  <!-- Firebase Core + Auth (10.12.0) -->
-  <!-- Firebase App (always required) -->
-  <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
-
-  <!-- Firebase Auth -->
-  <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-auth-compat.js"></script>
-
-  <!-- Firebase Firestore (optional) -->
-  <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore-compat.js"></script>
-
 
   <!-- DOMPurify for sanitizing HTML -->
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.min.js"></script>
@@ -199,7 +189,10 @@
       "clsx": "https://unpkg.com/clsx@2.1.1/dist/clsx.mjs",
       "@bpmn-io/diagram-js-ui/": "https://unpkg.com/@bpmn-io/diagram-js-ui@0.2.3/lib/",
       "htm": "https://unpkg.com/htm@3.1.1/dist/htm.module.js",
-      "preact": "https://unpkg.com/preact@10.26.9/dist/preact.module.js"
+      "preact": "https://unpkg.com/preact@10.26.9/dist/preact.module.js",
+      "firebase/app": "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js",
+      "firebase/auth": "https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js",
+      "firebase/firestore": "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js"
     }
   }
   </script>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,5 +1,7 @@
 import { Stream } from './core/stream.js';
 import { reactiveLoginModal } from './login.js';
+import { auth } from './firebase.js';
+import { signOut } from 'firebase/auth';
 
 export const logUser = new Stream('👤 Login');
 export let currentUser = null;
@@ -10,7 +12,7 @@ export function authMenuOption({ avatarStream, showSaveButton, currentTheme, reb
     label: logUser.get(),
     onClick: () => {
       if (currentUser) {
-        firebase.auth().signOut().then(() => {
+        signOut(auth).then(() => {
           logUser.set('👤 Login');
           avatarStream.set('flow.png');
           showSaveButton.set(false);

--- a/public/js/firebase.js
+++ b/public/js/firebase.js
@@ -1,13 +1,9 @@
-// Copy this file to firebase.js and replace the placeholder values with your Firebase project configuration.
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
-  apiKey: 'YOUR_API_KEY',
-  authDomain: 'YOUR_PROJECT.firebaseapp.com',
-  projectId: 'YOUR_PROJECT_ID'
-  // …
+  // TODO: replace with your Firebase project configuration
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- replace Firebase compat scripts with ES module initialization and exports
- update login/auth/app modules to use auth and Firestore via imports
- add Firebase import maps and remove global script tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8aefc6d883288bdc017c543c2a4d