### PR TITLE
refactor: statically import diagram picker

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -7,6 +7,7 @@ import { treeStream, setSelectedId, setOnSelect, togglePanel } from './component
 import { logUser, currentUser, authMenuOption } from './auth.js';
 import { initAddOnOverlays } from './addOnOverlays.js';
 import { initAddOnFiltering } from './addOnFiltering.js';
+import { openDiagramPickerModal } from './login.js';
 import { Stream } from './core/stream.js';
 import { createSimulation } from './core/simulation.js';
 import { currentTheme, applyThemeToPage, themedThemeSelector } from './core/theme.js';
@@ -79,8 +80,6 @@ const defaultXml = `<?xml version="1.0" encoding="UTF-8"?>
 // === Initial BPMN XML template ===
 const diagramXMLStream = new Stream(defaultXml);
 async function init() {
-  await import('./login.js').catch(() => console.warn('login.js failed to load.'));
-
   const { addOnStore } = window;
 
   const avatarStream = new Stream('flow.png');

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -128,7 +128,7 @@ export function reactiveLoginModal(themeStream = currentTheme) {
 
 
 
-function openDiagramPickerModal(themeStream = currentTheme) {
+export function openDiagramPickerModal(themeStream = currentTheme) {
   const pickStream = new Stream(null); // emits selected diagram or null
 
   const { modal, content } = createModal(themeStream, () => pickStream.set(null));


### PR DESCRIPTION
## Summary
- export diagram picker modal
- statically import the module in app.js and drop dynamic import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcbebe17c4832895fd7f0d8ff95d64