### PR TITLE
Use showToast module and remove global references

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2,6 +2,7 @@ import customReplaceModule from './modules/customReplaceMenuProvider.js';
 import { createRaciMatrix } from './components/raciMatrix.js';
 import { createTokenListPanel } from './components/tokenListPanel.js';
 import { reactiveButton, dropdownStream, avatarDropdown, openFlowSelectionModal, createDiagramOverlay } from './components/elements.js';
+import { showToast } from './components/elements.js';
 import { showProperties, hideSidebar } from './components/showProperties.js';
 import { treeStream, setSelectedId, setOnSelect, togglePanel } from './components/diagramTree.js';
 import { logUser, currentUser, authMenuOption } from './auth.js';

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -2,6 +2,7 @@ import { Stream } from './core/stream.js';
 import { reactiveLoginModal } from './login.js';
 import { auth } from './firebase.js';
 import { signOut } from 'firebase/auth';
+import { showToast } from './components/elements.js';
 
 export const logUser = new Stream('👤 Login');
 export let currentUser = null;
@@ -20,17 +21,13 @@ export function authMenuOption({ avatarStream, showSaveButton, currentTheme, reb
           window.currentUser = currentUser;
           rebuildMenu();
         }).catch(() => {
-          if (window.showToast) {
-            window.showToast('Logout failed: ', { type: 'error' });
-          }
+          showToast('Logout failed: ', { type: 'error' });
         });
       } else {
         const userStream = reactiveLoginModal(currentTheme);
         userStream.subscribe(result => {
           if (result instanceof Error) {
-            if (window.showToast) {
-              window.showToast(`Error: ${result.message}`, { type: 'error' });
-            }
+            showToast(`Error: ${result.message}`, { type: 'error' });
           } else if (result) {
             currentUser = result;
             window.currentUser = currentUser;

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,7 +1,7 @@
 import { Stream } from './core/stream.js';
 import { currentTheme } from './core/theme.js';
 import { createModal } from './components/modal.js';
-import { editText, reactiveButton, dropdownStream, showConfirmationDialog } from './components/elements.js';
+import { editText, reactiveButton, dropdownStream, showConfirmationDialog, showToast } from './components/elements.js';
 import { column, row } from './components/layout.js';
 import { auth, db } from './firebase.js';
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';


### PR DESCRIPTION
## Summary
- import showToast in main app and login modules
- use showToast directly in auth flow and drop window global checks
- expose showToast in login module for toast notifications

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc0aa22808328b3203aad7c5565e8