### PR TITLE
Export diagram metadata prompt

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -8,7 +8,7 @@ import { treeStream, setSelectedId, setOnSelect, togglePanel } from './component
 import { logUser, currentUser, authMenuOption } from './auth.js';
 import { initAddOnOverlays } from './addOnOverlays.js';
 import { initAddOnFiltering } from './addOnFiltering.js';
-import { openDiagramPickerModal } from './login.js';
+import { openDiagramPickerModal, promptDiagramMetadata } from './login.js';
 import { Stream } from './core/stream.js';
 import { createSimulation } from './core/simulation.js';
 import { currentTheme, applyThemeToPage, themedThemeSelector } from './core/theme.js';

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -276,7 +276,7 @@ export function openDiagramPickerModal(themeStream = currentTheme) {
 }
 
 
-function promptDiagramMetadata(initialName = '', initialNotes = '', themeStream = currentTheme) {
+export function promptDiagramMetadata(initialName = '', initialNotes = '', themeStream = currentTheme) {
   const resultStream = new Stream(null);
   const theme = themeStream.get();
   const colors = theme.colors;


### PR DESCRIPTION
## Summary
- export `promptDiagramMetadata` from `login.js`
- import `promptDiagramMetadata` in `app.js` alongside diagram picker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc8b4c3cc83288aacc7ba3a9aba1f