### PR TITLE
Export selectVersionModal for version switch modal

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -8,7 +8,7 @@ import { treeStream, setSelectedId, setOnSelect, togglePanel } from './component
 import { logUser, currentUser, authMenuOption } from './auth.js';
 import { initAddOnOverlays } from './addOnOverlays.js';
 import { initAddOnFiltering } from './addOnFiltering.js';
-import { openDiagramPickerModal, promptDiagramMetadata } from './login.js';
+import { openDiagramPickerModal, promptDiagramMetadata, selectVersionModal } from './login.js';
 import { Stream } from './core/stream.js';
 import { createSimulation } from './core/simulation.js';
 import { currentTheme, applyThemeToPage, themedThemeSelector } from './core/theme.js';

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -403,7 +403,7 @@ export function promptDiagramMetadata(initialName = '', initialNotes = '', theme
 }
 
 
-function selectVersionModal(diagramName, versions, themeStream = currentTheme) {
+export function selectVersionModal(diagramName, versions, themeStream = currentTheme) {
   const versionStream = new Stream((versions.length - 1).toString()); // Default to latest
   const pickStream = new Stream(null);   // Emits selected version index
 


### PR DESCRIPTION
## Summary
- export `selectVersionModal` from login utilities
- import `selectVersionModal` directly in `app.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcca8c84808328ae2db095f74df2bd