### PR TITLE
fix: correct token simulation import path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -185,11 +185,11 @@
       "firebase/app": "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js",
       "firebase/auth": "https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js",
       "firebase/firestore": "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js",
-      "bpmn-js-token-simulation": "https://unpkg.com/bpmn-js-token-simulation@0.32.0/dist/bpmn-js-token-simulation.esm.js"
+      "bpmn-js-token-simulation": "https://unpkg.com/bpmn-js-token-simulation@0.32.0/dist/index.esm.js?module"
     }
   }
   </script>
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="js/app.js" crossorigin="anonymous"></script>
   <!-- 7) more to come -->
 
 </body>


### PR DESCRIPTION
## Summary
- fix token simulation import map to use ESM `index.esm.js`
- allow cross-origin loading for module script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd72e2bc188328b3c4845556b159c7