### PR TITLE
fix: correct token simulation import path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -185,7 +185,7 @@
       "firebase/app": "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js",
       "firebase/auth": "https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js",
       "firebase/firestore": "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js",
-      "bpmn-js-token-simulation": "https://unpkg.com/bpmn-js-token-simulation@0.32.0/dist/index.esm.js?module"
+      "bpmn-js-token-simulation": "https://unpkg.com/bpmn-js-token-simulation@0.32.0/dist/index.esm.js"
     }
   }
   </script>


### PR DESCRIPTION
## Summary
- fix bpmn-js-token-simulation import path in import map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcd32e9af88328a5312924b56b4eff