### PR TITLE
fix: update token simulation import

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -185,7 +185,7 @@
       "firebase/app": "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js",
       "firebase/auth": "https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js",
       "firebase/firestore": "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js",
-      "bpmn-js-token-simulation": "https://unpkg.com/bpmn-js-token-simulation@0.32.0/dist/index.esm.js"
+      "bpmn-js-token-simulation": "https://unpkg.com/bpmn-js-token-simulation@0.32.0/dist/bpmn-js-token-simulation.esm.js"
     }
   }
   </script>


### PR DESCRIPTION
## Summary
- use correct bpmn-js-token-simulation ESM entry in import map

## Testing
- `npm test`
- `curl -L -sS https://unpkg.com/bpmn-js-token-simulation@0.32.0/dist/bpmn-js-token-simulation.esm.js` (fails: CONNECT tunnel failed, response 403)

------
https://chatgpt.com/codex/tasks/task_e_68bd7b4a4c74832885fe743cea89fb03