### PR TITLE
fix: correct token simulation import path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -185,7 +185,7 @@
       "firebase/app": "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js",
       "firebase/auth": "https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js",
       "firebase/firestore": "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js",
-      "bpmn-js-token-simulation": "node_modules/bpmn-js-token-simulation/dist/bpmn-js-token-simulation.esm.js"
+      "bpmn-js-token-simulation": "./node_modules/bpmn-js-token-simulation/dist/bpmn-js-token-simulation.esm.js"
     }
   }
   </script>


### PR DESCRIPTION
## Summary
- fix token simulation import map to use relative path

## Testing
- `npm test` *(fails: Cannot find package 'bpmn-moddle')*
- `curl -I http://localhost:8080/node_modules/bpmn-js-token-simulation/dist/bpmn-js-token-simulation.esm.js`
- `node --experimental-network-imports -e "import('http://localhost:8080/node_modules/bpmn-js-token-simulation/dist/bpmn-js-token-simulation.esm.js').then(m=>console.log('loaded')).catch(e=>console.error('error',e))"`

------
https://chatgpt.com/codex/tasks/task_e_68bd7e3a7dd883289c4e73ee1092a3f2