### PR TITLE
refactor: replace simulator provider with tokenSimulation

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -228,7 +228,7 @@ Object.assign(document.body.style, {
 
   const eventBus     = modeler.get('eventBus');
   const commandStack = modeler.get('commandStack');
-  const simulator    = modeler.get('simulator');
+  const tokenSimulation = modeler.get('tokenSimulation');
   const isDirty = new Stream(false);
   const showSaveButton = new Stream(false);
 
@@ -260,8 +260,8 @@ Object.assign(document.body.style, {
     setSelectedId(element?.id || null);
   });
 
-  if (simulator?.on) {
-    simulator.on('decision.required', event => {
+  if (tokenSimulation?.on) {
+    tokenSimulation.on('decision.required', event => {
       const { context } = event;
       const flows = (context?.outgoing || []).map(flow => ({ flow, satisfied: true }));
       const allowMultiple = context?.type === 'bpmn:InclusiveGateway';


### PR DESCRIPTION
## Summary
- update BPMN modeler to use `tokenSimulation` provider instead of `simulator`

## Testing
- `npm test` *(fails: Cannot find package 'bpmn-moddle' imported from test files)*
- `npm install` *(fails: 403 Forbidden for bpmn-js-token-simulation)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8133ed388328a7510fd2611ecc97