### PR TITLE
Add simulate button and token simulation toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,7 @@
 <body>
   <!-- Jazira toolbar will be injected here -->
   <button id="toggle-palette" aria-label="Toggle palette">Tools</button>
+  <button id="run-sim">Simulate</button>
   <!-- Palette + canvas wrapper -->
   <div id="diagram-wrapper" style="display:flex; flex:1; overflow:hidden">
     <div id="palette"></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -231,6 +231,8 @@ Object.assign(document.body.style, {
   const tokenSimulation = modeler.get('tokenSimulation');
   const isDirty = new Stream(false);
   const showSaveButton = new Stream(false);
+  document.getElementById('run-sim')
+    .addEventListener('click', () => tokenSimulation.toggle());
 
   // push every change into your XML Stream:
   eventBus.on('commandStack.changed', async () => {


### PR DESCRIPTION
## Summary
- Add `Simulate` button to main page
- Connect button to token simulation toggle in app script

## Testing
- `npm test` *(fails: Cannot find package 'bpmn-moddle')*

------
https://chatgpt.com/codex/tasks/task_e_68bd8aa18c9c83288af2163e5bfc6ba8