### PR TITLE
Replace standalone simulation button with toolbar control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -138,7 +138,6 @@
 <body>
   <!-- Jazira toolbar will be injected here -->
   <button id="toggle-palette" aria-label="Toggle palette">Tools</button>
-  <button id="run-sim">Simulate</button>
   <!-- Palette + canvas wrapper -->
   <div id="diagram-wrapper" style="display:flex; flex:1; overflow:hidden">
     <div id="palette"></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -231,8 +231,6 @@ Object.assign(document.body.style, {
   const tokenSimulation = modeler.get('tokenSimulation');
   const isDirty = new Stream(false);
   const showSaveButton = new Stream(false);
-  document.getElementById('run-sim')
-    .addEventListener('click', () => tokenSimulation.toggle());
 
   // push every change into your XML Stream:
   eventBus.on('commandStack.changed', async () => {
@@ -848,6 +846,12 @@ function rebuildMenu() {
   const controls = [
   // 1) avatar menu
   avatarMenu,
+
+  reactiveButton(
+    new Stream('Simulate'),
+    () => tokenSimulation.toggle(),
+    { outline: true, title: 'Toggle simulation' }
+  ),
 
   // ─── Continuous Zoom In ────────────────────────────────────────────────────
   reactiveButton(


### PR DESCRIPTION
## Summary
- remove legacy `run-sim` button and listener
- add reactive toolbar button to toggle token simulation

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bpmn-js-token-simulation)*
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'bpmn-moddle')*

------
https://chatgpt.com/codex/tasks/task_e_68bd93826e148328a9ad92927ca8e417