### PR TITLE
feat: ensure simulation button styled consistently

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -850,7 +850,7 @@ function rebuildMenu() {
   reactiveButton(
     new Stream('Simulate'),
     () => tokenSimulation.toggle(),
-    { outline: true, title: 'Toggle simulation' }
+    { outline: true, title: 'Toggle simulation', 'aria-label': 'Toggle simulation' }
   ),
 
   // ─── Continuous Zoom In ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add ARIA label to simulation toolbar button for consistent styling
- confirm no legacy `#run-sim` references remain

## Testing
- `npm test` *(fails: Cannot find package 'bpmn-moddle'; token simulation tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bd94627e6c8328bc1f54cd28425e1e