### PR TITLE
Use icon button for token simulation

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -331,3 +331,10 @@
   margin-right: 0;
 }
 
+.icon-btn {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+

--- a/public/index.html
+++ b/public/index.html
@@ -138,7 +138,11 @@
 <body>
   <!-- Jazira toolbar will be injected here -->
   <button id="toggle-palette" aria-label="Toggle palette">Tools</button>
-  <button id="run-sim">Simulate</button>
+  <button id="run-sim" class="icon-btn"
+          title="Start/stop token simulation"
+          aria-label="Start/stop token simulation">
+    &#9654;
+  </button>
   <!-- Palette + canvas wrapper -->
   <div id="diagram-wrapper" style="display:flex; flex:1; overflow:hidden">
     <div id="palette"></div>


### PR DESCRIPTION
## Summary
- replace "Simulate" button with icon-based start/stop button
- add `.icon-btn` style removing default button chrome

## Testing
- `npm test` *(fails: Cannot find package 'bpmn-moddle'; dependency install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68bd92462e88832886dcf8f3e036a21e