### PR TITLE
Auto-forward inclusive gateways with single matching path

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -419,7 +419,7 @@ let nextTokenId = 1;
       }
     };
 
-    const ids = Array.isArray(flowIds) ? flowIds : flowIds ? [flowIds] : null;
+    let ids = Array.isArray(flowIds) ? flowIds : flowIds ? [flowIds] : null;
     if (!ids || ids.length === 0) {
       const mapped = outgoing.map(flow => ({
         flow,
@@ -440,11 +440,16 @@ let nextTokenId = 1;
           }
         }
       }
-      pathsStream.set({ flows: mapped, type: token.element.type, isDefaultOnly: defaultOnly });
-      awaitingToken = token;
-      resumeAfterChoice = running;
-      pause();
-      return null;
+      const satisfied = mapped.filter(f => f.satisfied);
+      if (satisfied.length === 1) {
+        ids = [satisfied[0].flow.id];
+      } else {
+        pathsStream.set({ flows: mapped, type: token.element.type, isDefaultOnly: defaultOnly });
+        awaitingToken = token;
+        resumeAfterChoice = running;
+        pause();
+        return null;
+      }
     }
     const joins = findInclusiveJoin(token.element);
     return ids

--- a/test/inclusive-gateway.test.js
+++ b/test/inclusive-gateway.test.js
@@ -202,6 +202,22 @@ test('single-path diverging inclusive gateway auto forwards without confirmation
   assert.strictEqual(sim.pathsStream.get(), null);
 });
 
+test('diverging inclusive gateway auto forwards when only one condition matches', () => {
+  const diagram = buildDiagram('Diverging', 2);
+  const f1 = diagram.find(e => e.id === 'f1');
+  const f2 = diagram.find(e => e.id === 'f2');
+  f1.businessObject = { conditionExpression: { body: 'true' } };
+  f2.businessObject = { conditionExpression: { body: 'false' } };
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // move to gateway
+  sim.step(); // should auto-forward via f1
+  const token = sim.tokenStream.get()[0];
+  assert.strictEqual(token.element.id, 'task');
+  assert.strictEqual(token.viaFlow, 'f1');
+  assert.strictEqual(sim.pathsStream.get(), null);
+});
+
 test('findInclusiveJoin handles nested inclusive splits', () => {
   const elements = buildNestedDiagram();
   const map = new Map(elements.map(e => [e.id, e]));

--- a/test/simulation/inclusive-split-join.test.js
+++ b/test/simulation/inclusive-split-join.test.js
@@ -58,11 +58,17 @@ function buildSplitJoinDiagram(extraTaskOnB = false, omitDirection = false) {
 
 test('inclusive split/join with single selected path does not wait for others', () => {
   const diagram = buildSplitJoinDiagram();
+  const fa = diagram.find(e => e.id === 'fa');
+  const fb = diagram.find(e => e.id === 'fb');
+  fa.businessObject = { conditionExpression: { body: 'true' } };
+  fb.businessObject = { conditionExpression: { body: 'false' } };
   const sim = createSimulationInstance(diagram, { delay: 0 });
   sim.reset();
   sim.step(); // start -> split
-  sim.step(); // process gateway and wait for decision
-  sim.step(['fa']); // choose only path a
+  sim.step(); // gateway auto-forwards via fa
+  const atA = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(atA, ['a']);
+  assert.strictEqual(sim.pathsStream.get(), null);
   sim.step(); // a -> join
   const afterA = Array.from(sim.tokenStream.get(), t => t.element.id);
   assert.deepStrictEqual(afterA, ['join']);


### PR DESCRIPTION
## Summary
- skip user choice when an inclusive gateway evaluation yields a single path
- update inclusive gateway tests for automatic forwarding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc16887748328bf60897cd8da9fc7