### PR TITLE
Guard awaiting token in simulation step

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -642,6 +642,10 @@ let nextTokenId = 1;
 
     for (const token of tokens) {
       if (processed.has(token.id)) continue;
+      if (awaitingToken && token.id === awaitingToken.id && !skipHandlerFor.has(token.id) && !flowIds) {
+        newTokens.push(token);
+        continue;
+      }
       const el = token.element;
       const incomingCount = (el.incoming || []).length;
       const type = el.type;


### PR DESCRIPTION
## Summary
- avoid reprocessing a paused token in `step`

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68beec2a46248328aa583b47f6630efa