### PR TITLE
Continue simulation for runnable tokens

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -692,21 +692,11 @@ let nextTokenId = 1;
     tokens = newTokens;
     tokenStream.set(tokens);
     if (!awaitingToken) pathsStream.set(null);
+    const runnable = tokens.some(t => !awaitingToken || t.id !== awaitingToken.id);
 
-    if (!tokens.length) {
-      pause();
-      cleanup();
-      return;
-    }
-
-    if (!awaitingToken) {
-      if (resumeAfterChoice) {
-        resumeAfterChoice = false;
-        resume();
-      } else {
-        schedule();
-      }
-    }
+    if (!tokens.length) { pause(); cleanup(); return; }
+    if (runnable) { running = true; schedule(); }
+    else { pause(); }   // only the paused token remains
   }
 
   function start() {


### PR DESCRIPTION
## Summary
- allow simulation to continue for tokens not awaiting manual action
- pause only when no runnable tokens remain

## Testing
- `timeout 5s npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beee44cbb883288cdc71bf145cfe89