### PR TITLE
Handle invalid flow choice in exclusive gateway

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -348,7 +348,10 @@ let nextTokenId = 1;
       logToken(next);
       return [next];
     }
-    return [];
+
+    // invalid choice -> keep waiting
+    awaitingToken = token;
+    return null;
   }
 
   function handleParallelGateway(token, outgoing) {
@@ -676,6 +679,7 @@ let nextTokenId = 1;
       const { tokens: resTokens, waiting } = processToken(current, chosen);
       tokens = tokens.filter(t => t.id !== current.id);
       if (waiting) {
+        awaitingToken = current;
         newTokens.push(current, ...resTokens);
       } else {
         awaitingToken = null;


### PR DESCRIPTION
## Summary
- Detect invalid sequence flow selections in `handleExclusiveGateway` and keep waiting for a valid choice
- Ensure `step()` reinstates the awaiting token when an invalid flow is chosen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf5dbbb944832886506f6c8d9210f2