### PR TITLE
Respect previous running state after gateway choice

### DIFF
--- a/test/simulation/exclusive-gateway-choice.test.js
+++ b/test/simulation/exclusive-gateway-choice.test.js
@@ -339,3 +339,15 @@ test('simulation allows choice when all gateway conditions are unsatisfied', () 
   assert.strictEqual(sim.pathsStream.get(), null);
 });
 
+test('manual step after exclusive gateway does not auto resume', async () => {
+  const diagram = buildDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 1 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // evaluate and pause
+  sim.step('fa'); // choose a path while paused
+  await new Promise(r => setTimeout(r, 5));
+  const after = Array.from(sim.tokenStream.get(), t => t.element.id);
+  assert.deepStrictEqual(after, ['a']);
+});
+


### PR DESCRIPTION
## Summary
- track whether the simulation was running before a gateway paused execution
- resume automatically only when the simulation was previously running
- add regression test ensuring manual stepping stays paused after a choice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf671b3fb483289775e2eb39fb08ce