### PR TITLE
feat: resume simulation after user choice

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -693,7 +693,12 @@ let nextTokenId = 1;
         awaitingToken = null;
         pathsStream.set(null);
         newTokens.push(...resTokens);
+        if (resumeAfterChoice) {
+          running = true;
+          schedule();
+        }
       }
+      resumeAfterChoice = false;
     }
 
     if (!tokens.length && !newTokens.length) return;


### PR DESCRIPTION
## Summary
- resume running immediately after user chooses a gateway path
- clear resumeAfterChoice once the selection is handled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0220868c883288198b5f3b3bbe6a3