### PR TITLE
Add automatic timer event handling

### DIFF
--- a/test/simulation/manual-resume.test.js
+++ b/test/simulation/manual-resume.test.js
@@ -23,34 +23,6 @@ function buildUserTaskDiagram() {
   return [start, user, after, f0, f1];
 }
 
-function buildTimerDiagram() {
-  const start = {
-    id: 'Start',
-    type: 'bpmn:StartEvent',
-    incoming: [],
-    outgoing: [],
-    businessObject: { $type: 'bpmn:StartEvent' }
-  };
-  const timer = {
-    id: 'Timer',
-    type: 'bpmn:IntermediateCatchEvent',
-    incoming: [],
-    outgoing: [],
-    businessObject: {
-      $type: 'bpmn:IntermediateCatchEvent',
-      eventDefinitions: [{ $type: 'bpmn:TimerEventDefinition' }]
-    }
-  };
-  const after = { id: 'After', type: 'bpmn:Task', incoming: [], outgoing: [] };
-  const f0 = { id: 'f0', type: 'bpmn:SequenceFlow', source: start, target: timer };
-  const f1 = { id: 'f1', type: 'bpmn:SequenceFlow', source: timer, target: after };
-  start.outgoing = [f0];
-  timer.incoming = [f0];
-  timer.outgoing = [f1];
-  after.incoming = [f1];
-  return [start, timer, after, f0, f1];
-}
-
 // UserTask manual resume
 
 test('UserTask pauses until manually resumed', async () => {
@@ -69,20 +41,3 @@ test('UserTask pauses until manually resumed', async () => {
   assert.deepStrictEqual(ids, ['After']);
 });
 
-// TimerEvent manual resume
-
-test('TimerEvent pauses until manually resumed', async () => {
-  const diagram = buildTimerDiagram();
-  const sim = createSimulationInstance(diagram, { delay: 0 });
-  sim.reset();
-  sim.step(); // start -> timer
-  sim.step(); // process timer event and pause
-  let ids = sim.tokenStream.get().map(t => t.element && t.element.id);
-  assert.deepStrictEqual(ids, ['Timer']);
-  await new Promise(r => setTimeout(r, 10));
-  ids = sim.tokenStream.get().map(t => t.element && t.element.id);
-  assert.deepStrictEqual(ids, ['Timer']);
-  sim.step(); // manual resume
-  ids = sim.tokenStream.get().map(t => t.element && t.element.id);
-  assert.deepStrictEqual(ids, ['After']);
-});

--- a/test/simulation/start-events.test.js
+++ b/test/simulation/start-events.test.js
@@ -39,7 +39,12 @@ function buildTimerStartDiagram() {
     outgoing: [],
     businessObject: {
       $type: 'bpmn:StartEvent',
-      eventDefinitions: [{ $type: 'bpmn:TimerEventDefinition' }]
+      eventDefinitions: [
+        {
+          $type: 'bpmn:TimerEventDefinition',
+          timeDuration: { body: 'PT0.01S' }
+        }
+      ]
     }
   };
   const after = { id: 'After', type: 'bpmn:UserTask', incoming: [], outgoing: [] };
@@ -60,18 +65,14 @@ test('message start event proceeds automatically', async () => {
   assert.deepStrictEqual(ids, ['TaskMessage']);
 });
 
-// Timer start event requires manual resume
+// Timer start event resumes after specified duration
 
-test('timer start event waits for manual trigger', async () => {
+test('timer start event proceeds after duration', async () => {
   const diagram = buildTimerStartDiagram();
   const sim = createSimulationInstance(diagram, { delay: 1 });
   sim.start('StartTimer');
-  await new Promise(r => setTimeout(r, 20));
-  let ids = Array.from(sim.tokenStream.get(), t => t.element && t.element.id);
-  assert.deepStrictEqual(ids, ['StartTimer']);
-  sim.resume();
-  await new Promise(r => setTimeout(r, 20));
-  ids = Array.from(sim.tokenStream.get(), t => t.element && t.element.id);
+  await new Promise(r => setTimeout(r, 30));
+  const ids = Array.from(sim.tokenStream.get(), t => t.element && t.element.id);
   assert.deepStrictEqual(ids, ['After']);
 });
 

--- a/test/simulation/timer-events.test.js
+++ b/test/simulation/timer-events.test.js
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSimulationInstance } from '../helpers/simulation.js';
+
+function buildTimerDiagram(prop, expr) {
+  const start = {
+    id: 'Start',
+    type: 'bpmn:StartEvent',
+    incoming: [],
+    outgoing: [],
+    businessObject: { $type: 'bpmn:StartEvent' }
+  };
+  const timer = {
+    id: 'Timer',
+    type: 'bpmn:IntermediateCatchEvent',
+    incoming: [],
+    outgoing: [],
+    businessObject: {
+      $type: 'bpmn:IntermediateCatchEvent',
+      eventDefinitions: [
+        {
+          $type: 'bpmn:TimerEventDefinition',
+          [prop]: { body: expr }
+        }
+      ]
+    }
+  };
+  const after = { id: 'After', type: 'bpmn:UserTask', incoming: [], outgoing: [] };
+  const f0 = { id: 'f0', type: 'bpmn:SequenceFlow', source: start, target: timer };
+  const f1 = { id: 'f1', type: 'bpmn:SequenceFlow', source: timer, target: after };
+  start.outgoing = [f0];
+  timer.incoming = [f0];
+  timer.outgoing = [f1];
+  after.incoming = [f1];
+  return [start, timer, after, f0, f1];
+}
+
+test('TimerEvent resumes after timeDuration', async () => {
+  const diagram = buildTimerDiagram('timeDuration', 'PT0.01S');
+  const sim = createSimulationInstance(diagram, { delay: 1 });
+  sim.reset();
+  sim.step();
+  sim.step();
+  await new Promise(r => setTimeout(r, 30));
+  const ids = sim.tokenStream.get().map(t => t.element && t.element.id);
+  assert.deepStrictEqual(ids, ['After']);
+});
+
+test('TimerEvent resumes after timeDate', async () => {
+  const date = new Date(Date.now() + 20).toISOString();
+  const diagram = buildTimerDiagram('timeDate', date);
+  const sim = createSimulationInstance(diagram, { delay: 1 });
+  sim.reset();
+  sim.step();
+  sim.step();
+  await new Promise(r => setTimeout(r, 40));
+  const ids = sim.tokenStream.get().map(t => t.element && t.element.id);
+  assert.deepStrictEqual(ids, ['After']);
+});
+
+test('TimerEvent resumes after timeCycle', async () => {
+  const diagram = buildTimerDiagram('timeCycle', 'R/PT0.01S');
+  const sim = createSimulationInstance(diagram, { delay: 1 });
+  sim.reset();
+  sim.step();
+  sim.step();
+  await new Promise(r => setTimeout(r, 30));
+  const ids = sim.tokenStream.get().map(t => t.element && t.element.id);
+  assert.deepStrictEqual(ids, ['After']);
+});


### PR DESCRIPTION
## Summary
- parse BPMN timer event definitions for timeDuration, timeDate or timeCycle and auto-resume after delay
- adjust start event behavior and add comprehensive timer event tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c075b0750c8328ba456ffac9d3d408