### PR TITLE
feat: sandboxed expression evaluator

### DIFF
--- a/public/js/core/simulation.js
+++ b/public/js/core/simulation.js
@@ -2,6 +2,294 @@
 
 import { Stream } from './stream.js';
 
+// Sandboxed expression evaluator supporting a subset of JS syntax
+// (boolean, comparison and arithmetic operators). Identifiers not present
+// in the provided context will cause evaluation to throw, allowing callers
+// to treat missing variables according to BPMN rules.
+function safeEval(expression, context = {}, missingValue) {
+  const tokens = tokenize(expression);
+  let pos = 0;
+
+  function peek() {
+    return tokens[pos];
+  }
+
+  function consume(value) {
+    const token = tokens[pos];
+    if (!token || (value && token.value !== value)) {
+      throw new Error('Unexpected token: ' + (token ? token.value : 'EOF'));
+    }
+    pos++;
+    return token;
+  }
+
+  function parseExpression() {
+    return parseLogicalOr();
+  }
+
+  function parseLogicalOr() {
+    let node = parseLogicalAnd();
+    while (peek() && peek().type === 'op' && peek().value === '||') {
+      const op = consume('||').value;
+      const right = parseLogicalAnd();
+      node = { type: 'Binary', op, left: node, right };
+    }
+    return node;
+  }
+
+  function parseLogicalAnd() {
+    let node = parseEquality();
+    while (peek() && peek().type === 'op' && peek().value === '&&') {
+      const op = consume('&&').value;
+      const right = parseEquality();
+      node = { type: 'Binary', op, left: node, right };
+    }
+    return node;
+  }
+
+  function parseEquality() {
+    let node = parseComparison();
+    while (
+      peek() &&
+      peek().type === 'op' &&
+      ['==', '!=', '===', '!=='].includes(peek().value)
+    ) {
+      const op = consume(peek().value).value;
+      const right = parseComparison();
+      node = { type: 'Binary', op, left: node, right };
+    }
+    return node;
+  }
+
+  function parseComparison() {
+    let node = parseAdditive();
+    while (
+      peek() &&
+      peek().type === 'op' &&
+      ['<', '<=', '>', '>='].includes(peek().value)
+    ) {
+      const op = consume(peek().value).value;
+      const right = parseAdditive();
+      node = { type: 'Binary', op, left: node, right };
+    }
+    return node;
+  }
+
+  function parseAdditive() {
+    let node = parseMultiplicative();
+    while (peek() && peek().type === 'op' && ['+', '-'].includes(peek().value)) {
+      const op = consume(peek().value).value;
+      const right = parseMultiplicative();
+      node = { type: 'Binary', op, left: node, right };
+    }
+    return node;
+  }
+
+  function parseMultiplicative() {
+    let node = parseUnary();
+    while (peek() && peek().type === 'op' && ['*', '/', '%'].includes(peek().value)) {
+      const op = consume(peek().value).value;
+      const right = parseUnary();
+      node = { type: 'Binary', op, left: node, right };
+    }
+    return node;
+  }
+
+  function parseUnary() {
+    if (peek() && peek().type === 'op' && ['!', '+', '-'].includes(peek().value)) {
+      const op = consume(peek().value).value;
+      const argument = parseUnary();
+      return { type: 'Unary', op, argument };
+    }
+    return parsePrimary();
+  }
+
+  function parsePrimary() {
+    const token = peek();
+    if (!token) throw new Error('Unexpected end of expression');
+    if (token.type === 'number' || token.type === 'string' || token.type === 'boolean') {
+      consume();
+      return { type: 'Literal', value: token.value };
+    }
+    if (token.type === 'identifier') {
+      consume();
+      return { type: 'Identifier', name: token.value };
+    }
+    if (token.type === 'paren' && token.value === '(') {
+      consume('(');
+      const expr = parseExpression();
+      consume(')');
+      return expr;
+    }
+    throw new Error('Unexpected token: ' + token.value);
+  }
+
+  function evaluate(node) {
+    switch (node.type) {
+      case 'Literal':
+        return node.value;
+      case 'Identifier':
+        if (Object.prototype.hasOwnProperty.call(context, node.name)) {
+          return context[node.name];
+        }
+        return missingValue;
+      case 'Unary': {
+        const val = evaluate(node.argument);
+        switch (node.op) {
+          case '!':
+            return !val;
+          case '+':
+            return +val;
+          case '-':
+            return -val;
+          default:
+            throw new Error('Unknown operator: ' + node.op);
+        }
+      }
+      case 'Binary': {
+        if (node.op === '&&') {
+          return evaluate(node.left) && evaluate(node.right);
+        }
+        if (node.op === '||') {
+          return evaluate(node.left) || evaluate(node.right);
+        }
+        const left = evaluate(node.left);
+        const right = evaluate(node.right);
+        switch (node.op) {
+          case '===':
+            return left === right;
+          case '!==':
+            return left !== right;
+          case '==':
+            return left == right; // eslint-disable-line eqeqeq
+          case '!=':
+            return left != right; // eslint-disable-line eqeqeq
+          case '>':
+            return left > right;
+          case '<':
+            return left < right;
+          case '>=':
+            return left >= right;
+          case '<=':
+            return left <= right;
+          case '+':
+            return left + right;
+          case '-':
+            return left - right;
+          case '*':
+            return left * right;
+          case '/':
+            return left / right;
+          case '%':
+            return left % right;
+          default:
+            throw new Error('Unknown operator: ' + node.op);
+        }
+      }
+      default:
+        throw new Error('Unknown node type: ' + node.type);
+    }
+  }
+
+  const ast = parseExpression();
+  if (pos < tokens.length) {
+    throw new Error('Unexpected token: ' + tokens[pos].value);
+  }
+  return evaluate(ast);
+}
+
+function tokenize(input) {
+  const tokens = [];
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+    if (/\s/.test(ch)) {
+      i++;
+      continue;
+    }
+
+    // multi-character operators
+    const op3 = input.slice(i, i + 3);
+    if (op3 === '===') {
+      tokens.push({ type: 'op', value: '===' });
+      i += 3;
+      continue;
+    }
+    if (op3 === '!==') {
+      tokens.push({ type: 'op', value: '!==' });
+      i += 3;
+      continue;
+    }
+    const op2 = input.slice(i, i + 2);
+    if (['&&', '||', '>=', '<=', '==', '!='].includes(op2)) {
+      tokens.push({ type: 'op', value: op2 });
+      i += 2;
+      continue;
+    }
+
+    if ('><+-*/%!'.includes(ch)) {
+      tokens.push({ type: 'op', value: ch });
+      i++;
+      continue;
+    }
+
+    if (ch === '(' || ch === ')') {
+      tokens.push({ type: 'paren', value: ch });
+      i++;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      let str = '';
+      i++;
+      while (i < input.length) {
+        const c = input[i];
+        if (c === '\\') {
+          str += input[i + 1];
+          i += 2;
+          continue;
+        }
+        if (c === quote) {
+          i++;
+          break;
+        }
+        str += c;
+        i++;
+      }
+      tokens.push({ type: 'string', value: str });
+      continue;
+    }
+
+    if (/[0-9]/.test(ch)) {
+      let num = ch;
+      i++;
+      while (i < input.length && /[0-9.]/.test(input[i])) {
+        num += input[i++];
+      }
+      tokens.push({ type: 'number', value: Number(num) });
+      continue;
+    }
+
+    if (/[A-Za-z_$]/.test(ch)) {
+      let id = ch;
+      i++;
+      while (i < input.length && /[A-Za-z0-9_$]/.test(input[i])) {
+        id += input[i++];
+      }
+      if (id === 'true' || id === 'false') {
+        tokens.push({ type: 'boolean', value: id === 'true' });
+      } else {
+        tokens.push({ type: 'identifier', value: id });
+      }
+      continue;
+    }
+
+    throw new Error('Unexpected character: ' + ch);
+  }
+  return tokens;
+}
+
 // Simple token simulation service built on Streams
 // Usage:
 //   const simulation = createSimulation({ elementRegistry, canvas, context: { foo: true } }, { delay: 500 });
@@ -39,6 +327,19 @@ export function createSimulation(services, opts = {}) {
   // Stream of available sequence flows when waiting on a gateway decision.
   // This acts as the signal to prompt the user for input on which path to take.
   const pathsStream = new Stream(null);
+
+  function evaluate(expr, data) {
+    if (!expr) return true;
+    const raw = (expr.body || expr.value || '').toString().trim();
+    const js = raw.replace(/^\$\{?|\}$/g, '');
+    if (!js) return true;
+    try {
+      return !!safeEval(js, data || {}, conditionFallback);
+    } catch (err) {
+      console.warn('Failed to evaluate condition', js, err);
+      return conditionFallback;
+    }
+  }
 
   const TOKEN_LOG_STORAGE_KEY = 'simulationTokenLog';
 
@@ -335,26 +636,6 @@ let nextTokenId = 1;
     // `flowId` is the id of the chosen sequence flow (string)
     // Determine viable flows based on conditions when no flowId is provided
     if (!flowId) {
-      const evaluate = (expr, data) => {
-        if (!expr) return true;
-        const raw = (expr.body || expr.value || '').toString().trim();
-        const js = raw.replace(/^\$\{?|\}$/g, '');
-        if (!js) return true;
-        const proxy = new Proxy(data || {}, {
-          has: () => true,
-          get(target, prop) {
-            if (prop === Symbol.unscopables) return undefined;
-            return prop in target ? target[prop] : conditionFallback;
-          }
-        });
-        try {
-          return !!Function('context', 'with(context){ return (' + js + '); }')(proxy);
-        } catch (err) {
-          console.warn('Failed to evaluate condition', js, err);
-          return conditionFallback;
-        }
-      };
-
       const mapped = outgoing.map(flow => ({
         flow,
         satisfied: evaluate(
@@ -515,27 +796,6 @@ let nextTokenId = 1;
     if (!diverging) {
       return handleDefault(token, outgoing);
     }
-
-    const evaluate = (expr, data) => {
-      if (!expr) return true;
-      const raw = (expr.body || expr.value || '').toString().trim();
-      const js = raw.replace(/^\$\{?|\}$/g, '');
-      if (!js) return true;
-      const proxy = new Proxy(data || {}, {
-        has: () => true,
-        get(target, prop) {
-          if (prop === Symbol.unscopables) return undefined;
-          return prop in target ? target[prop] : conditionFallback;
-        }
-      });
-      try {
-        return !!Function('context', 'with(context){ return (' + js + '); }')(proxy);
-      } catch (err) {
-        console.warn('Failed to evaluate condition', js, err);
-        return conditionFallback;
-      }
-    };
-
     let ids = Array.isArray(flowIds) ? flowIds : flowIds ? [flowIds] : null;
     if (!ids || ids.length === 0) {
       const mapped = outgoing.map(flow => ({

--- a/test/simulation/unsafe-expression.test.js
+++ b/test/simulation/unsafe-expression.test.js
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSimulationInstance } from '../helpers/simulation.js';
+
+function buildDiagram() {
+  const start = {
+    id: 'start',
+    type: 'bpmn:StartEvent',
+    outgoing: [],
+    incoming: [],
+    businessObject: { $type: 'bpmn:StartEvent' }
+  };
+  const gw = {
+    id: 'gw',
+    type: 'bpmn:ExclusiveGateway',
+    businessObject: { gatewayDirection: 'Diverging' },
+    incoming: [],
+    outgoing: []
+  };
+  const a = { id: 'a', type: 'bpmn:Task', incoming: [], outgoing: [] };
+  const b = { id: 'b', type: 'bpmn:Task', incoming: [], outgoing: [] };
+
+  const f0 = { id: 'f0', source: start, target: gw };
+  start.outgoing = [f0];
+  gw.incoming = [f0];
+
+  const f1 = {
+    id: 'f1',
+    source: gw,
+    target: a,
+    businessObject: { conditionExpression: { body: '${(function(){ globalThis.__hacked = true; return true; })()}' } }
+  };
+  const f2 = {
+    id: 'f2',
+    source: gw,
+    target: b,
+    businessObject: { conditionExpression: { body: '${false}' } }
+  };
+  gw.outgoing = [f1, f2];
+  a.incoming = [f1];
+  b.incoming = [f2];
+
+  return [start, gw, a, b, f0, f1, f2];
+}
+
+test('unsafe expressions are sandboxed and do not execute', () => {
+  // ensure no residue
+  globalThis.__hacked = undefined;
+  const diagram = buildDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> gateway
+  sim.step(); // evaluate and pause awaiting user choice
+  assert.strictEqual(globalThis.__hacked, undefined);
+  assert.ok(sim.pathsStream.get());
+});


### PR DESCRIPTION
## Summary
- replace Function-based evaluation with sandboxed interpreter and consistent fallback handling
- prevent unsafe expressions from executing during simulation
- add regression test for unsafe expression handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c08084286c83289144b036913565f2