### PR TITLE
Handle message events via dispatcher and listeners

### DIFF
--- a/test/simulation/message-flow-concurrency.test.js
+++ b/test/simulation/message-flow-concurrency.test.js
@@ -17,7 +17,10 @@ function buildDiagram() {
     type: 'bpmn:StartEvent',
     incoming: [],
     outgoing: [],
-    businessObject: { $type: 'bpmn:StartEvent' }
+    businessObject: {
+      $type: 'bpmn:StartEvent',
+      eventDefinitions: [{ $type: 'bpmn:MessageEventDefinition' }]
+    }
   };
   const nextB = { id: 'Task_B', type: 'bpmn:Task', incoming: [], outgoing: [] };
 

--- a/test/simulation/message-flow.test.js
+++ b/test/simulation/message-flow.test.js
@@ -41,7 +41,7 @@ function buildDiagram(targetParticipant = false) {
   return [startA, task, next, msgTarget, f0, fSeq, m1];
 }
 
-test('task sends message and continues along sequence flow', () => {
+test('message flow to start event without message definition is ignored', () => {
   const diagram = buildDiagram(false);
   const sim = createSimulationInstance(diagram, { delay: 0 });
   sim.reset();


### PR DESCRIPTION
## Summary
- emit messages over a dispatcher instead of spawning tokens directly
- allow message events and message start events to wait for and consume messages
- add tests ensuring messages only trigger receivers with catch or start events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0827cb6a083288c17b52de477ca1e