### PR TITLE
Support multiple start events in simulation

### DIFF
--- a/public/js/core/README.md
+++ b/public/js/core/README.md
@@ -100,6 +100,19 @@ The simulation exposes methods such as `start`, `pause`, and `step` to drive
 execution. Use `step(flowId)` when a gateway waits for user input to select the
 next paths.
 
+### Start events
+
+`start(startId)` and `reset(startId)` accept an optional BPMN start event ID.
+When provided, only the matching start event is initialized. Without an ID,
+the simulation creates a token for every start event without incoming flows,
+allowing multiple starts to run in parallel.
+
+```js
+sim.start('StartEvent_1');
+// or reset to a specific start
+sim.reset('StartEvent_1');
+```
+
 ### Selecting outgoing flows
 
 `step` expects the IDs of the sequence flows that should be taken:

--- a/test/simulation/start-events.test.js
+++ b/test/simulation/start-events.test.js
@@ -76,14 +76,17 @@ test('timer start event proceeds after duration', async () => {
   assert.deepStrictEqual(ids, ['After']);
 });
 
-// When multiple start events exist, default to the one without event definition
+// When multiple start events exist, tokens are created for each start event
 
-test('defaults to none start event when multiple start nodes exist', async () => {
+test('starts all start events when none specified', async () => {
   const diagram = buildMultiStartDiagram();
   const sim = createSimulationInstance(diagram, { delay: 1 });
   sim.start();
   await new Promise(r => setTimeout(r, 20));
-  const ids = Array.from(sim.tokenStream.get(), t => t.element && t.element.id);
-  assert.deepStrictEqual(ids, ['TaskNone']);
+  const ids = Array.from(
+    sim.tokenStream.get(),
+    t => t.element && t.element.id
+  ).sort();
+  assert.deepStrictEqual(ids, ['TaskMessage', 'TaskNone']);
 });
 


### PR DESCRIPTION
## Summary
- return arrays of eligible start events and allow running all of them
- spawn a token for each start event during start and reset
- prompt user for start event selection and document start ID support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0997ed75c8328a44925a552335967