### PR TITLE
Cleanup boundary tokens when hosts complete

### DIFF
--- a/test/simulation/boundary-events.test.js
+++ b/test/simulation/boundary-events.test.js
@@ -119,3 +119,14 @@ test('non-interrupting message boundary can trigger multiple times', () => {
   const count = ids.filter(id => id === 'OnMessage').length;
   assert.equal(count, 2);
 });
+
+test('boundary token removed when host completes without activation', () => {
+  const diagram = buildTimerDiagram();
+  const sim = createSimulationInstance(diagram, { delay: 0 });
+  sim.reset();
+  sim.step(); // start -> task
+  sim.step(); // spawn boundary token and pause user task
+  sim.step(); // manually complete user task
+  const ids = sim.tokenStream.get().map(t => t.element && t.element.id);
+  assert.deepStrictEqual(ids, ['After']);
+});


### PR DESCRIPTION
## Summary
- map host tokens to spawned boundary tokens
- remove boundary tokens once their host finishes or boundary fires
- add regression test for boundary cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0a47cb07483289ddc75bbd8a60817