### PR TITLE
feat: allow choosing start event via modal

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -431,6 +431,116 @@ export function headerContainer(titleStream) {
 }
 
 
+export function openStartEventSelectionModal(events, themeStream = currentTheme) {
+  const pickStream = new Stream(null);
+
+  // Overlay
+  const modal = document.createElement('div');
+  Object.assign(modal.style, {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100vw',
+    height: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    zIndex: 9999
+  });
+
+  // Content box
+  const content = document.createElement('div');
+  Object.assign(content.style, {
+    padding: '1.5rem',
+    borderRadius: '8px',
+    boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+    minWidth: '300px',
+    maxHeight: '80vh',
+    overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem'
+  });
+
+  const title = document.createElement('h3');
+  title.textContent = 'Select Start Event';
+  content.appendChild(title);
+
+  const list = document.createElement('div');
+  list.style.display = 'flex';
+  list.style.flexDirection = 'column';
+  list.style.gap = '0.5rem';
+  content.appendChild(list);
+
+  events.forEach(ev => {
+    const label = document.createElement('label');
+    Object.assign(label.style, {
+      padding: '0.5rem 1rem',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.5rem'
+    });
+
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = 'startEventSelection';
+    input.value = ev.id;
+
+    const span = document.createElement('span');
+    span.textContent = ev.businessObject?.name || ev.id;
+
+    label.appendChild(input);
+    label.appendChild(span);
+    list.appendChild(label);
+  });
+
+  const confirmBtn = document.createElement('button');
+  confirmBtn.textContent = 'Confirm';
+  confirmBtn.style.marginTop = '1rem';
+  confirmBtn.addEventListener('click', () => {
+    const selected = Array.from(list.querySelectorAll('input')).find(i => i.checked);
+    pickStream.set(selected ? selected.value : null);
+    modal.remove();
+  });
+  content.appendChild(confirmBtn);
+
+  modal.appendChild(content);
+  document.body.appendChild(modal);
+
+  const applyStyles = theme => {
+    const { colors, fonts } = theme;
+    content.style.backgroundColor = colors.surface || '#fff';
+    content.style.color = colors.foreground || '#000';
+    content.style.fontFamily = fonts.base || 'sans-serif';
+    Array.from(list.children).forEach(child => {
+      child.style.backgroundColor = colors.primary || '#f9f9f9';
+      child.style.border = `1px solid ${colors.border || '#ccc'}`;
+      child.onmouseover = () => child.style.backgroundColor = colors.accent + '55';
+      child.onmouseout = () => child.style.backgroundColor = colors.primary || '#f9f9f9';
+    });
+    confirmBtn.style.backgroundColor = colors.primary || '#f9f9f9';
+    confirmBtn.style.border = `1px solid ${colors.border || '#ccc'}`;
+    confirmBtn.onmouseover = () => confirmBtn.style.backgroundColor = colors.accent + '55';
+    confirmBtn.onmouseout = () => confirmBtn.style.backgroundColor = colors.primary || '#f9f9f9';
+  };
+
+  themeStream.subscribe(applyStyles);
+  applyStyles(themeStream.get());
+
+  modal.addEventListener('click', e => {
+    if (e.target === modal) {
+      pickStream.set(null);
+      modal.remove();
+    }
+  });
+
+  return pickStream;
+}
+
+
 export function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple = false) {
   const pickStream = new Stream(null);
 

--- a/test/simulation/start-event-choice-modal.test.js
+++ b/test/simulation/start-event-choice-modal.test.js
@@ -1,0 +1,111 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSimulationInstance } from '../helpers/simulation.js';
+import { Stream } from '../../public/js/core/stream.js';
+import { openStartEventSelectionModal } from '../../public/js/components/elements.js';
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.style = {};
+    this._text = '';
+    this.parentNode = null;
+    this.events = {};
+  }
+  set textContent(val) {
+    this._text = String(val);
+  }
+  get textContent() {
+    return this._text + this.children.map(c => c.textContent).join('');
+  }
+  appendChild(child) {
+    this.children.push(child);
+    child.parentNode = this;
+  }
+  remove() {
+    if (this.parentNode) {
+      const idx = this.parentNode.children.indexOf(this);
+      if (idx >= 0) this.parentNode.children.splice(idx, 1);
+      this.parentNode = null;
+    }
+  }
+  addEventListener(type, fn) {
+    this.events[type] = fn;
+  }
+  contains(el) {
+    if (this === el) return true;
+    return this.children.some(child => child.contains && child.contains(el));
+  }
+  querySelectorAll(selector) {
+    const results = [];
+    const traverse = node => {
+      node.children.forEach(child => {
+        if (selector === 'input' && child.tagName === 'input') results.push(child);
+        traverse(child);
+      });
+    };
+    traverse(this);
+    return results;
+  }
+}
+
+class Document {
+  constructor() {
+    this.body = new Element('body');
+  }
+  createElement(tag) {
+    return new Element(tag);
+  }
+  querySelectorAll(selector) {
+    return this.body.querySelectorAll(selector);
+  }
+}
+
+function setupDom() {
+  const document = new Document();
+  const oldDoc = global.document;
+  const oldWin = global.window;
+  const oldNode = global.Node;
+  global.document = document;
+  global.window = { document };
+  global.Node = Element;
+  return { document, themeStream: new Stream({ colors: {}, fonts: {} }), restore() { global.document = oldDoc; global.window = oldWin; global.Node = oldNode; } };
+}
+
+function buildMultiStartDiagram() {
+  const startA = { id: 'StartNone', type: 'bpmn:StartEvent', incoming: [], outgoing: [], businessObject: { $type: 'bpmn:StartEvent', name: 'None' } };
+  const startB = { id: 'StartMessage', type: 'bpmn:StartEvent', incoming: [], outgoing: [], businessObject: { $type: 'bpmn:StartEvent', name: 'Message' } };
+  const taskA = { id: 'TaskNone', type: 'bpmn:UserTask', incoming: [], outgoing: [] };
+  const taskB = { id: 'TaskMessage', type: 'bpmn:UserTask', incoming: [], outgoing: [] };
+  const f0 = { id: 'f0', source: startA, target: taskA };
+  const f1 = { id: 'f1', source: startB, target: taskB };
+  startA.outgoing = [f0];
+  taskA.incoming = [f0];
+  startB.outgoing = [f1];
+  taskB.incoming = [f1];
+  return [startA, startB, taskA, taskB, f0, f1];
+}
+
+test('selecting start event via modal starts simulation at chosen event', async () => {
+  const { document, themeStream, restore } = setupDom();
+  try {
+    const diagram = buildMultiStartDiagram();
+    const sim = createSimulationInstance(diagram, { delay: 1 });
+    const startEvents = diagram.filter(e => e.type === 'bpmn:StartEvent');
+    const pickStream = openStartEventSelectionModal(startEvents, themeStream);
+    const inputs = document.querySelectorAll('input');
+    inputs[1].checked = true;
+    const modal = document.body.children[0];
+    const content = modal.children[0];
+    const confirmBtn = content.children.find(c => c.tagName === 'button');
+    confirmBtn.events['click']();
+    const selectedId = await new Promise(res => pickStream.subscribe(v => v && res(v)));
+    sim.start(selectedId);
+    await new Promise(r => setTimeout(r, 20));
+    const ids = Array.from(sim.tokenStream.get(), t => t.element && t.element.id);
+    assert.deepStrictEqual(ids, ['TaskMessage']);
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
## Summary
- add `openStartEventSelectionModal` to let users pick a start event
- make start/reset operations await async `chooseStartEvent`
- test choosing from multiple start events via modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1785c508c83288bf7b033f8d2a195