### PR TITLE
Reset simulation without automatic start selection

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -486,7 +486,7 @@ async function appendXml(xml) {
       const svg = canvasEl.querySelector('svg');
       if (svg) svg.style.height = '100%';
       simulation.clearTokenLog();
-      simulation.reset(await chooseStartEvent());
+      simulation.reset();
     } catch (err) {
       console.error("Import error:", err);
     }


### PR DESCRIPTION
## Summary
- Stop auto-selecting a start event during XML import
- Ensure simulation resets without a start ID until user starts or resets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17bd815ac8328a3803a76756253b4