### PR TITLE
feat: show pause status and resume control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -108,6 +108,13 @@
     stroke-width: 4px;
   }
 
+  /* highlight element waiting for user action */
+  .djs-element.awaiting .djs-visual > :nth-child(1),
+  .djs-connection.awaiting .djs-visual > :nth-child(1) {
+    stroke: #ffc107;
+    stroke-width: 4px;
+  }
+
   /* mobile palette toggle */
   #toggle-palette {
     display: none;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -216,6 +216,37 @@ Object.assign(document.body.style, {
   window.simulation = simulation;
   const overlays        = modeler.get('overlays');
 
+  // status display when simulation is awaiting user action
+  const statusBar = document.createElement('div');
+  statusBar.id = 'simulation-status';
+  Object.assign(statusBar.style, {
+    position: 'fixed',
+    bottom: '1rem',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    background: '#fff',
+    border: '1px solid #ccc',
+    padding: '0.5rem 1rem',
+    display: 'none',
+    zIndex: '1000'
+  });
+  const statusText = document.createElement('span');
+  const resumeBtn = document.createElement('button');
+  resumeBtn.textContent = 'Resume';
+  resumeBtn.addEventListener('click', () => simulation.resume());
+  statusBar.appendChild(statusText);
+  statusBar.appendChild(resumeBtn);
+  document.body.appendChild(statusBar);
+
+  simulation.statusStream.subscribe(info => {
+    if (info) {
+      statusText.textContent = `Paused at ${info.elementName || info.elementId}: ${info.reason}`;
+      statusBar.style.display = 'block';
+    } else {
+      statusBar.style.display = 'none';
+    }
+  });
+
   async function chooseStartEvent() {
     const all = elementRegistry.filter
       ? elementRegistry.filter(


### PR DESCRIPTION
## Summary
- emit pause status through new simulation statusStream
- highlight awaiting elements and show message with resume button
- style waiting elements for visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c17c9b50048328b75c12e9904bb604