### PR TITLE
Handle null start event selection

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -259,9 +259,12 @@ Object.assign(document.body.style, {
     if (eligible.length <= 1) return eligible[0]?.id;
     const stream = openStartEventSelectionModal(eligible, currentTheme);
     return await new Promise(resolve => {
-      const unsub = stream.subscribe(val => {
-        resolve(val);
-        unsub();
+      let unsubscribe;
+      unsubscribe = stream.subscribe(val => {
+        if (val) {
+          resolve(val);
+          unsubscribe?.();
+        }
       });
     });
   }


### PR DESCRIPTION
## Summary
- ignore initial null from start event selection
- unsubscribe from stream after resolving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1913af97483288c075f7f3143c640