### PR TITLE
Deduplicate start event options

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -255,7 +255,13 @@ Object.assign(document.body.style, {
             e.businessObject?.$type === 'bpmn:StartEvent'
         )
       : [];
-    const eligible = all.filter(e => !e.incoming || !e.incoming.length);
+    const eligible = [
+      ...new Map(
+        all
+          .filter(e => !e.incoming || !e.incoming.length)
+          .map(e => [e.id, e])
+      ).values()
+    ];
     if (eligible.length <= 1) return eligible[0]?.id;
     const stream = openStartEventSelectionModal(eligible, currentTheme);
     return await new Promise(resolve => {


### PR DESCRIPTION
## Summary
- Remove duplicate start events by ID when selecting start event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c192c286288328ab1a4ffa30e1211f