### PR TITLE
Handle single flow selection for exclusive gateways

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -521,7 +521,7 @@ export function openFlowSelectionModal(flows, themeStream = currentTheme, allowM
     list.querySelectorAll('input').forEach((input, idx) => {
       if (input.checked) selected.push(flows[idx].flow);
     });
-    pickStream.set(selected);
+    pickStream.set(allowMultiple ? selected : selected[0] || null);
     modal.remove();
   });
   content.appendChild(confirmBtn);


### PR DESCRIPTION
## Summary
- Ensure `openFlowSelectionModal` emits a single flow when only one selection is allowed

## Testing
- `npm test` *(fails: 29 tests fail, 33 pass)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a70623748328ab0235d0cf95168d