### PR TITLE
Normalize flow selection modal input

### DIFF
--- a/public/js/components/elements.js
+++ b/public/js/components/elements.js
@@ -432,6 +432,7 @@ export function headerContainer(titleStream) {
 
 
 export function openFlowSelectionModal(flows, themeStream = currentTheme, allowMultiple = false) {
+  const items = flows.map(f => ('flow' in f ? f : { flow: f, satisfied: true }));
   const pickStream = new Stream(null);
 
   // Overlay
@@ -473,7 +474,7 @@ export function openFlowSelectionModal(flows, themeStream = currentTheme, allowM
   list.style.gap = '0.5rem';
   content.appendChild(list);
 
-  flows.forEach(({ flow, satisfied }) => {
+  items.forEach(({ flow, satisfied }) => {
     const label = document.createElement('label');
     Object.assign(label.style, {
       padding: '0.5rem 1rem',
@@ -519,7 +520,7 @@ export function openFlowSelectionModal(flows, themeStream = currentTheme, allowM
   confirmBtn.addEventListener('click', () => {
     const selected = [];
     list.querySelectorAll('input').forEach((input, idx) => {
-      if (input.checked) selected.push(flows[idx].flow);
+      if (input.checked) selected.push(items[idx].flow);
     });
     pickStream.set(allowMultiple ? selected : selected[0] || null);
     modal.remove();


### PR DESCRIPTION
## Summary
- Allow `openFlowSelectionModal` to accept raw `SequenceFlow` objects or `{ flow, satisfied }` wrappers
- Use normalized list for rendering and selection to avoid `flow.target` errors

## Testing
- `npm test` *(fails: 33 passing, 29 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cb42c97c8328b246185bbcff8b07