### PR TITLE
feat: theme-specific BPMN element colors

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1069,11 +1069,29 @@ currentTheme.subscribe(theme => {
       background: ${colors.background} !important;
     }
 
-    /* ── force all shape backgrounds to theme.surface ────────────────────── */
+    /* ── base shape styles ──────────────────────────────────────────────── */
     .djs-element .djs-shape {
-      fill: ${colors.surface} !important;
+      fill: ${bpmn.shape.fill} !important;
       stroke: ${bpmn.shape.stroke} !important;
       stroke-width: ${bpmn.shape.strokeWidth}px !important;
+    }
+
+    /* ── BPMN element specifics ─────────────────────────────────────────── */
+    .djs-element[class*="start-event"] .djs-shape {
+      fill: ${bpmn.startEvent.fill} !important;
+      stroke: ${bpmn.startEvent.stroke} !important;
+    }
+    .djs-element[class*="end-event"] .djs-shape {
+      fill: ${bpmn.endEvent.fill} !important;
+      stroke: ${bpmn.endEvent.stroke} !important;
+    }
+    .djs-element[class*="task"] .djs-shape {
+      fill: ${bpmn.task.fill} !important;
+      stroke: ${bpmn.task.stroke} !important;
+    }
+    .djs-element[class*="gateway"] .djs-shape {
+      fill: ${bpmn.gateway.fill} !important;
+      stroke: ${bpmn.gateway.stroke} !important;
     }
 
     /* keep event outlines clear if you like: */

--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -34,6 +34,22 @@
       "selected": {
         "stroke": "#ff00ff",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#00e676",
+        "stroke": "#666"
+      },
+      "endEvent": {
+        "fill": "#ff5252",
+        "stroke": "#666"
+      },
+      "task": {
+        "fill": "#1e1e1e",
+        "stroke": "#666"
+      },
+      "gateway": {
+        "fill": "#ffb300",
+        "stroke": "#666"
       }
     },
     "fonts": {
@@ -76,6 +92,22 @@
       "selected": {
         "stroke": "#6200ee",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#4caf50",
+        "stroke": "#ccc"
+      },
+      "endEvent": {
+        "fill": "#f44336",
+        "stroke": "#ccc"
+      },
+      "task": {
+        "fill": "#f5f5f5",
+        "stroke": "#ccc"
+      },
+      "gateway": {
+        "fill": "#fb8c00",
+        "stroke": "#ccc"
       }
     },
     "fonts": {
@@ -118,6 +150,22 @@
       "selected": {
         "stroke": "#ff00ff",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#00e6a8",
+        "stroke": "#1c3a5f"
+      },
+      "endEvent": {
+        "fill": "#ff4d6d",
+        "stroke": "#1c3a5f"
+      },
+      "task": {
+        "fill": "#112240",
+        "stroke": "#1c3a5f"
+      },
+      "gateway": {
+        "fill": "#ffa726",
+        "stroke": "#1c3a5f"
       }
     },
     "fonts": {
@@ -160,6 +208,22 @@
       "selected": {
         "stroke": "#ff00ff",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#859900",
+        "stroke": "#586e75"
+      },
+      "endEvent": {
+        "fill": "#dc322f",
+        "stroke": "#586e75"
+      },
+      "task": {
+        "fill": "#073642",
+        "stroke": "#586e75"
+      },
+      "gateway": {
+        "fill": "#b58900",
+        "stroke": "#586e75"
       }
     },
     "fonts": {
@@ -202,6 +266,22 @@
       "selected": {
         "stroke": "#268bd2",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#859900",
+        "stroke": "#93a1a1"
+      },
+      "endEvent": {
+        "fill": "#dc322f",
+        "stroke": "#93a1a1"
+      },
+      "task": {
+        "fill": "#eee8d5",
+        "stroke": "#93a1a1"
+      },
+      "gateway": {
+        "fill": "#b58900",
+        "stroke": "#93a1a1"
       }
     },
     "fonts": {
@@ -244,6 +324,22 @@
       "selected": {
         "stroke": "#ff00ff",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#4caf50",
+        "stroke": "#4caf50"
+      },
+      "endEvent": {
+        "fill": "#e57373",
+        "stroke": "#4caf50"
+      },
+      "task": {
+        "fill": "#3a4d37",
+        "stroke": "#4caf50"
+      },
+      "gateway": {
+        "fill": "#ffb74d",
+        "stroke": "#4caf50"
       }
     },
     "fonts": {
@@ -286,6 +382,22 @@
       "selected": {
         "stroke": "#ff69b4",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#66bb6a",
+        "stroke": "#ff99cc"
+      },
+      "endEvent": {
+        "fill": "#ef5350",
+        "stroke": "#ff99cc"
+      },
+      "task": {
+        "fill": "#ffd6f3",
+        "stroke": "#ff99cc"
+      },
+      "gateway": {
+        "fill": "#ffb74d",
+        "stroke": "#ff99cc"
       }
     },
     "fonts": {
@@ -328,6 +440,22 @@
       "selected": {
         "stroke": "#ff00ff",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#00e676",
+        "stroke": "#2a2a5c"
+      },
+      "endEvent": {
+        "fill": "#ff5252",
+        "stroke": "#2a2a5c"
+      },
+      "task": {
+        "fill": "#16213e",
+        "stroke": "#2a2a5c"
+      },
+      "gateway": {
+        "fill": "#ffb74d",
+        "stroke": "#2a2a5c"
       }
     },
     "fonts": {
@@ -370,6 +498,22 @@
       "selected": {
         "stroke": "#9bc1bc",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#6b8e23",
+        "stroke": "#c5a880"
+      },
+      "endEvent": {
+        "fill": "#8b0000",
+        "stroke": "#c5a880"
+      },
+      "task": {
+        "fill": "#e6beae",
+        "stroke": "#c5a880"
+      },
+      "gateway": {
+        "fill": "#b8860b",
+        "stroke": "#c5a880"
       }
     },
     "fonts": {
@@ -412,6 +556,22 @@
       "selected": {
         "stroke": "#00ff00",
         "strokeWidth": 3
+      },
+      "startEvent": {
+        "fill": "#00ff00",
+        "stroke": "#00aa00"
+      },
+      "endEvent": {
+        "fill": "#ff0000",
+        "stroke": "#00aa00"
+      },
+      "task": {
+        "fill": "#004400",
+        "stroke": "#00aa00"
+      },
+      "gateway": {
+        "fill": "#ffff00",
+        "stroke": "#00aa00"
       }
     },
     "fonts": {


### PR DESCRIPTION
## Summary
- define start/end/task/gateway colors for each theme
- apply theme BPMN element colors in generated CSS rules

## Testing
- `npm test` *(fails: diverging inclusive gateway auto forwards when only one condition matches, non-interrupting message boundary can trigger multiple times, boundary token removed when host completes without activation, call activity invokes called process, multi-instance subprocess waits for all instances)*

------
https://chatgpt.com/codex/tasks/task_e_68c59edac0508328adb9784c29f8c948