### PR TITLE
refactor: use theme variables for tree and token colors

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -78,7 +78,7 @@
 }
 
 .diagram-tree-selected {
-  background: #ffd54f;
+  background: var(--accent);
 }
 
 .diagram-tree-owner {
@@ -230,11 +230,11 @@
 }
 
 .token-entry-even {
-  background-color: #f9f9f9;
+  background-color: var(--panel);
 }
 
 .token-entry-odd {
-  background-color: #e9e9e9;
+  background-color: var(--panel2);
 }
 
 .token-entry-start::before {
@@ -262,7 +262,7 @@
 }
 
 @keyframes token-entry-highlight {
-  from { background-color: #fff3cd; }
+  from { background-color: var(--accent); }
   to { background-color: inherit; }
 }
 

--- a/test/theme-highlight.test.js
+++ b/test/theme-highlight.test.js
@@ -16,9 +16,10 @@ test('applyThemeToPage sets highlight variables', async () => {
       }
     }
   };
-  const theme = {
+  const theme1 = {
     colors: {
       panel: '#1e1e1e',
+      panel2: '#2e2e2e',
       text: '#f0f0f0',
       border: '#666666',
       accent: '#ff9800',
@@ -26,13 +27,34 @@ test('applyThemeToPage sets highlight variables', async () => {
     },
     fonts: {}
   };
+  const theme2 = {
+    colors: {
+      panel: '#eeeeee',
+      panel2: '#dddddd',
+      text: '#010101',
+      border: '#222222',
+      accent: '#00ff00',
+      ok: '#008800'
+    },
+    fonts: {}
+  };
   const { applyThemeToPage } = await import('../public/js/core/theme.js');
-  applyThemeToPage(theme, body);
+  applyThemeToPage(theme1, body);
   assert.equal(body.style['--panel'], '#1e1e1e');
+  assert.equal(body.style['--panel2'], '#2e2e2e');
   assert.equal(body.style['--text'], '#f0f0f0');
   assert.equal(body.style['--border'], '#666666');
   assert.equal(body.style['--accent'], '#ff9800');
   assert.equal(body.style['--ok'], '#52b415');
+
+  // applying a new theme should update the variables
+  applyThemeToPage(theme2, body);
+  assert.equal(body.style['--panel'], '#eeeeee');
+  assert.equal(body.style['--panel2'], '#dddddd');
+  assert.equal(body.style['--text'], '#010101');
+  assert.equal(body.style['--border'], '#222222');
+  assert.equal(body.style['--accent'], '#00ff00');
+  assert.equal(body.style['--ok'], '#008800');
 });
 
 test('app.css uses CSS variables for overlays', async () => {
@@ -41,4 +63,8 @@ test('app.css uses CSS variables for overlays', async () => {
   assert.ok(/\.djs-element\.bpmn-addOn-highlight .djs-visual > :nth-child\(1\)\s*\{[^}]*stroke:\s*var\(--accent\);[^}]*fill:\s*var\(--accent\);[^}]*filter:\s*drop-shadow\(0 0 6px var\(--accent\)\)/s.test(css));
   assert.ok(/\.djs-element\.drop-ok .djs-visual > :nth-child\(1\)\s*\{[^}]*stroke:\s*var\(--ok\);[^}]*fill:\s*var\(--ok\);[^}]*filter:\s*drop-shadow\(0 0 6px var\(--ok\)\)/s.test(css));
   assert.ok(/\.djs-connection\.bpmn-addOn-highlight .djs-visual > :nth-child\(1\)\s*\{[^}]*stroke:\s*var\(--accent\)/s.test(css));
+  assert.ok(/\.diagram-tree-selected\s*\{[^}]*background:\s*var\(--accent\)/s.test(css));
+  assert.ok(/\.token-entry-even\s*\{[^}]*background-color:\s*var\(--panel\)/s.test(css));
+  assert.ok(/\.token-entry-odd\s*\{[^}]*background-color:\s*var\(--panel2\)/s.test(css));
+  assert.ok(/@keyframes token-entry-highlight\s*\{[^}]*from\s*{[^}]*background-color:\s*var\(--accent\)/s.test(css));
 });


### PR DESCRIPTION
## Summary
- replace fixed highlight and token colors with theme variables
- extend theme utilities and tests for new `--panel2` variable
- verify tree selection and token entries adapt to theme changes

## Testing
- `npm test` *(fails: diverging inclusive gateway auto forwards when only one condition matches, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a17e0d048328a32c85339150f5bd