### PR TITLE
Use theme accent color for active token highlights

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1126,7 +1126,7 @@ currentTheme.subscribe(theme => {
     /* ── simulation active token highlight ─────────────────────────────── */
     .djs-element.active .djs-visual > :nth-child(1),
     .djs-connection.active .djs-visual > path {
-      stroke: orange !important;
+      stroke: ${colors.accent} !important;
       stroke-width: 4px !important;
     }
 


### PR DESCRIPTION
## Summary
- replace hard-coded orange token highlight with current theme accent color
- verify all themes specify an accent color

## Testing
- `node --test test/theme-highlight.test.js`
- `node --test test/simulation/flow-markers.test.js`
- `npm test` *(fails: diverging inclusive gateway auto forwards when only one condition matches, non-interrupting message boundary can trigger multiple times, boundary token removed when host completes without activation, call activity invokes called process, multi-instance subprocess waits for all instances, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a2d00c548328a9ff0bc833e2eb14