### PR TITLE
Use theme label color with fallback

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1102,9 +1102,9 @@ currentTheme.subscribe(theme => {
       stroke-width: ${bpmn.shape.strokeWidth}px !important;
     }
 
-    /* ── text labels use theme.foreground ───────────────────────────────── */
+    /* ── text labels use theme-defined fill with foreground fallback ───── */
     .djs-element .djs-label {
-      fill: ${colors.foreground} !important;
+      fill: ${bpmn.label.fill || colors.foreground} !important;
       font-family: ${bpmn.label.fontFamily} !important;
     }
 

--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -261,7 +261,7 @@
       },
       "label": {
         "fontFamily": "Georgia, serif",
-        "fill": "#657b83"
+        "fill": "#586e75"
       },
       "selected": {
         "stroke": "#268bd2",


### PR DESCRIPTION
## Summary
- Render BPMN text labels with theme-specific fill color, falling back to the theme foreground when unspecified
- Tweak Solarized Light theme label color for better contrast on its light canvas

## Testing
- `npm test` *(fails: 26/66)*
- `node contrast_check.js` (inline script) verifying all theme label colors now exceed 4.5 contrast ratio

------
https://chatgpt.com/codex/tasks/task_e_68c5a91b06508328a96929794fdc0c59