### PR TITLE
refactor: soften dark theme accent colors

### DIFF
--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -3,9 +3,9 @@
     "name": "Dark",
     "colors": {
       "background": "#121212",
-      "foreground": "#00ffcc",
+      "foreground": "#e0e0e0",
       "primary": "#1e1e1e",
-      "accent": "#ff00ff",
+      "accent": "#bb86fc",
       "surface": "#1e1e1e",
       "border": "#666",
       "muted": "#888888",
@@ -20,19 +20,19 @@
         "strokeWidth": 2
       },
       "connection": {
-        "stroke": "#00ffcc",
+        "stroke": "#bb86fc",
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#00ffcc",
-        "stroke": "#00ffcc"
+        "fill": "#bb86fc",
+        "stroke": "#bb86fc"
       },
       "label": {
         "fontFamily": "system-ui, sans-serif",
-        "fill": "#00ffcc"
+        "fill": "#bb86fc"
       },
       "selected": {
-        "stroke": "#ff00ff",
+        "stroke": "#bb86fc",
         "strokeWidth": 3
       },
       "startEvent": {


### PR DESCRIPTION
## Summary
- soften dark theme foreground to `#e0e0e0` and accent to `#bb86fc`
- update BPMN connection, marker, label, and selection to use the new accent

## Testing
- `python3 - <<'PY'
import sys
from math import pow

def luminance(hex):
    hex=hex.lstrip('#')
    r=int(hex[0:2],16)/255
    g=int(hex[2:4],16)/255
    b=int(hex[4:6],16)/255
    def adj(c):
        return c/12.92 if c<=0.03928 else pow((c+0.055)/1.055,2.4)
    r,g,b=adj(r),adj(g),adj(b)
    return 0.2126*r+0.7152*g+0.0722*b

def contrast(hex1,hex2):
    L1=luminance(hex1)
    L2=luminance(hex2)
    lighter=max(L1,L2)
    darker=min(L1,L2)
    return (lighter+0.05)/(darker+0.05)

bg='#121212'
accent='#bb86fc'
fg='#e0e0e0'
print('accent vs background', contrast(bg, accent))
print('foreground vs background', contrast(bg, fg))
PY`
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc456b68832886503a8102e9276a