### PR TITLE
chore(theme): refine light palette layering

### DIFF
--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -60,21 +60,21 @@
   "light": {
     "name": "Light",
     "colors": {
-      "background": "#ffffff",
+      "background": "#fafafa",
       "foreground": "#222222",
       "primary": "#f5f5f5",
       "accent": "#6200ee",
-      "surface": "#f7f7f7",
-      "border": "#ccc",
-      "muted": "#666666",
+      "surface": "#ffffff",
+      "border": "#d0d0d0",
+      "muted": "#555555",
       "ok": "#4caf50",
       "warn": "#fb8c00",
       "err": "#f44336"
     },
     "bpmn": {
       "shape": {
-        "fill": "#f7f7f7",
-        "stroke": "#ccc",
+        "fill": "#ffffff",
+        "stroke": "#d0d0d0",
         "strokeWidth": 2
       },
       "connection": {
@@ -95,19 +95,19 @@
       },
       "startEvent": {
         "fill": "#4caf50",
-        "stroke": "#ccc"
+        "stroke": "#d0d0d0"
       },
       "endEvent": {
         "fill": "#f44336",
-        "stroke": "#ccc"
+        "stroke": "#d0d0d0"
       },
       "task": {
         "fill": "#f5f5f5",
-        "stroke": "#ccc"
+        "stroke": "#d0d0d0"
       },
       "gateway": {
         "fill": "#fb8c00",
-        "stroke": "#ccc"
+        "stroke": "#d0d0d0"
       }
     },
     "fonts": {


### PR DESCRIPTION
## Summary
- adjust light theme background and surface colors for clearer layering
- update border and muted text colors for better contrast
- align BPMN shape fills and strokes with the new colors

## Testing
- `npm test` *(fails: 26 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bcebecb08328bba605e64e01cb04