### PR TITLE
feat: refine matrix theme palette

### DIFF
--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -525,7 +525,7 @@
     "name": "Matrix",
     "colors": {
       "background": "#000000",
-      "foreground": "#00ff00",
+      "foreground": "#e0ffe0",
       "primary": "#004400",
       "accent": "#00ff00",
       "surface": "#002200",
@@ -542,16 +542,16 @@
         "strokeWidth": 2
       },
       "connection": {
-        "stroke": "#00ff00",
+        "stroke": "#00bfa5",
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#00ff00",
-        "stroke": "#00ff00"
+        "fill": "#00bfa5",
+        "stroke": "#00bfa5"
       },
       "label": {
         "fontFamily": "\"Share Tech Mono\", monospace",
-        "fill": "#00ff00"
+        "fill": "#e0ffe0"
       },
       "selected": {
         "stroke": "#00ff00",


### PR DESCRIPTION
## Summary
- introduce neutral foreground in matrix theme
- add teal secondary hue for connections and markers
- keep bright green for accents and OK state

## Testing
- `python - <<'PY' ...` (color-blindness simulation)
- `npm test` (fails: diverging inclusive gateway auto forwards when only one condition matches, non-interrupting message boundary can trigger multiple times, call activity invokes called process, multi-instance subprocess waits for all instances, and others)


------
https://chatgpt.com/codex/tasks/task_e_68c5bea37bd88328907831c2e408770c