### PR TITLE
feat(theme): enhance matrix label contrast

### DIFF
--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -551,7 +551,7 @@
       },
       "label": {
         "fontFamily": "\"Share Tech Mono\", monospace",
-        "fill": "#e0ffe0"
+        "fill": "#00ff00"
       },
       "selected": {
         "stroke": "#00ff00",


### PR DESCRIPTION
## Summary
- improve Matrix theme label contrast by using the accent color `#00ff00`

## Testing
- `npm test` *(fails: 26 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c00b8af083288bc54e7b13ba2b1e