### PR TITLE
lighten dark theme connections

### DIFF
--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -20,12 +20,12 @@
         "strokeWidth": 2
       },
       "connection": {
-        "stroke": "#bb86fc",
+        "stroke": "#d1b6ff",
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#bb86fc",
-        "stroke": "#bb86fc"
+        "fill": "#d1b6ff",
+        "stroke": "#d1b6ff"
       },
       "label": {
         "fontFamily": "system-ui, sans-serif",

--- a/test/theme-connection.test.js
+++ b/test/theme-connection.test.js
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+
+// ensure no network fetch attempts from theme.js
+global.fetch = () => Promise.resolve({ json: () => Promise.resolve({}) });
+
+test('dark theme uses updated connection colors', async () => {
+  const themes = JSON.parse(
+    await fs.readFile(new URL('../public/js/core/themes.json', import.meta.url), 'utf8')
+  );
+  const dark = themes.dark;
+  assert.equal(dark.bpmn.connection.stroke, '#d1b6ff');
+  assert.equal(dark.bpmn.marker.fill, '#d1b6ff');
+  assert.equal(dark.bpmn.marker.stroke, '#d1b6ff');
+});


### PR DESCRIPTION
## Summary
- lighten dark theme connection and marker colors for better visibility
- add test covering dark theme connection color

## Testing
- `npm test` *(fails: diverging inclusive gateway auto forwards when only one condition matches, signal catch resumes on sendSignal, etc.)*
- `node --test test/theme-connection.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5cc41255c832887115d3316101366