### PR TITLE
feat: halo for connections

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1109,14 +1109,18 @@ currentTheme.subscribe(theme => {
     }
 
     /* ── connections & arrows ───────────────────────────────────────────── */
-    .djs-connection .djs-connection-inner,
-    .djs-connection .djs-connection-outer {
+    .djs-connection .djs-connection-inner {
       stroke: ${bpmn.connection.stroke} !important;
       stroke-width: ${bpmn.connection.strokeWidth}px !important;
     }
+    .djs-connection .djs-connection-outer {
+      stroke: ${bpmn.connectionOuter || colors.background};
+      stroke-width: ${bpmn.connection.strokeWidth + 2}px !important;
+    }
     .djs-connection .djs-marker {
-      fill: ${bpmn.marker.fill} !important;
-      stroke: ${bpmn.marker.stroke} !important;
+      fill: ${bpmn.marker.fill};
+      stroke: ${bpmn.markerOutline || colors.background};
+      stroke-width: 1px;
     }
 
     /* ── selected styles ───────────────────────────────────────────────── */

--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -27,6 +27,8 @@
         "fill": "#d1b6ff",
         "stroke": "#d1b6ff"
       },
+      "connectionOuter": "#121212",
+      "markerOutline": "#121212",
       "label": {
         "fontFamily": "system-ui, sans-serif",
         "fill": "#bb86fc"
@@ -143,6 +145,8 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
+      "connectionOuter": "#0a192f",
+      "markerOutline": "#0a192f",
       "label": {
         "fontFamily": "Roboto, sans-serif",
         "fill": "#00ffcc"
@@ -201,6 +205,8 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
+      "connectionOuter": "#002b36",
+      "markerOutline": "#002b36",
       "label": {
         "fontFamily": "Arial, sans-serif",
         "fill": "#00ffcc"
@@ -317,6 +323,8 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
+      "connectionOuter": "#2e3d29",
+      "markerOutline": "#2e3d29",
       "label": {
         "fontFamily": "Verdana, sans-serif",
         "fill": "#00ffcc"
@@ -433,6 +441,8 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
+      "connectionOuter": "#1a1a2e",
+      "markerOutline": "#1a1a2e",
       "label": {
         "fontFamily": "Helvetica Neue, sans-serif",
         "fill": "#00ffcc"
@@ -549,6 +559,8 @@
         "fill": "#00bfa5",
         "stroke": "#00bfa5"
       },
+      "connectionOuter": "#000000",
+      "markerOutline": "#000000",
       "label": {
         "fontFamily": "\"Share Tech Mono\", monospace",
         "fill": "#00ff00"


### PR DESCRIPTION
## Summary
- style BPMN connection outer lines as a halo using theme background or `connectionOuter`
- outline connection markers with theme background or `markerOutline`
- add `connectionOuter`/`markerOutline` color slots to dark themes

## Testing
- `npm test` *(fails: 26)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ce105d9c83288897214e0c89e49a