### PR TITLE
refactor: restore static overlay colors

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,32 +1,30 @@
 
 .djs-direct-editing-parent,
 .djs-direct-editing-content {
-  background: var(--panel);
-  color: var(--text);
-  border: 1px solid var(--border);
-  outline: 1px solid var(--border);
+  background: #1e1e1e;
+  color: #f0f0f0;
+  border: 1px solid #666;
+  outline: 1px solid #666;
 }
 
 
 .djs-element.bpmn-addOn-highlight .djs-visual > :nth-child(1) {
-  stroke: var(--accent);
+  stroke: #ff9800;
   stroke-width: 4px;
-  fill: var(--accent);
-  fill-opacity: 0.3;
-  filter: drop-shadow(0 0 6px var(--accent));
+  fill: rgba(255, 152, 0, 0.3);
+  filter: drop-shadow(0 0 6px #ff9800);
 }
 
 
 .djs-element.drop-ok .djs-visual > :nth-child(1) {
-  stroke: var(--ok);
+  stroke: #52b415;
   stroke-width: 4px;
-  fill: var(--ok);
-  fill-opacity: 0.3;
-  filter: drop-shadow(0 0 6px var(--ok));
+  fill: rgba(82, 180, 21, 0.3);
+  filter: drop-shadow(0 0 6px #52b415);
 }
 
 .djs-connection.bpmn-addOn-highlight .djs-visual > :nth-child(1) {
-  stroke: var(--accent);
+  stroke: #ff9800;
   stroke-width: 4px;
 }
 

--- a/public/js/core/theme.js
+++ b/public/js/core/theme.js
@@ -193,13 +193,7 @@ export function applyThemeToPage(theme, container = document.body) {
     '--panel2': colors.panel2 || colors.surface,
     '--text': colors.text || colors.foreground,
     '--muted': colors.muted || colors.foreground,
-    '--accent': colors.accent || colors.foreground,
-    '--accent-2':
-      colors['accent-2'] || colors.accent2 || colors.accent || colors.foreground,
-    '--border': colors.border || colors.foreground,
-    '--ok': colors.ok || colors.accent || colors.foreground,
-    '--warn': colors.warn || colors.accent || colors.foreground,
-    '--err': colors.err || colors.accent || colors.foreground
+    '--border': colors.border || colors.foreground
   };
 
   Object.entries(vars).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- reinstate fixed hex colors for editing and highlight overlays
- drop overlay/highlight theme variables

## Testing
- `npm test` *(fails: 28 failing tests)*
- `python -m http.server 8000 -d public` *(manually checked startup; no further validation possible)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f5e583c48328b65b7c6e68bb9bda