### PR TITLE
Revert PR #110: restore theme-aware overlay colors

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,30 +1,32 @@
 
 .djs-direct-editing-parent,
 .djs-direct-editing-content {
-  background: #1e1e1e;
-  color: #f0f0f0;
-  border: 1px solid #666;
-  outline: 1px solid #666;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  outline: 1px solid var(--border);
 }
 
 
 .djs-element.bpmn-addOn-highlight .djs-visual > :nth-child(1) {
-  stroke: #ff9800;
+  stroke: var(--accent);
   stroke-width: 4px;
-  fill: rgba(255, 152, 0, 0.3);
-  filter: drop-shadow(0 0 6px #ff9800);
+  fill: var(--accent);
+  fill-opacity: 0.3;
+  filter: drop-shadow(0 0 6px var(--accent));
 }
 
 
 .djs-element.drop-ok .djs-visual > :nth-child(1) {
-  stroke: #52b415;
+  stroke: var(--ok);
   stroke-width: 4px;
-  fill: rgba(82, 180, 21, 0.3);
-  filter: drop-shadow(0 0 6px #52b415);
+  fill: var(--ok);
+  fill-opacity: 0.3;
+  filter: drop-shadow(0 0 6px var(--ok));
 }
 
 .djs-connection.bpmn-addOn-highlight .djs-visual > :nth-child(1) {
-  stroke: #ff9800;
+  stroke: var(--accent);
   stroke-width: 4px;
 }
 

--- a/public/js/core/theme.js
+++ b/public/js/core/theme.js
@@ -193,7 +193,13 @@ export function applyThemeToPage(theme, container = document.body) {
     '--panel2': colors.panel2 || colors.surface,
     '--text': colors.text || colors.foreground,
     '--muted': colors.muted || colors.foreground,
-    '--border': colors.border || colors.foreground
+    '--accent': colors.accent || colors.foreground,
+    '--accent-2':
+      colors['accent-2'] || colors.accent2 || colors.accent || colors.foreground,
+    '--border': colors.border || colors.foreground,
+    '--ok': colors.ok || colors.accent || colors.foreground,
+    '--warn': colors.warn || colors.accent || colors.foreground,
+    '--err': colors.err || colors.accent || colors.foreground
   };
 
   Object.entries(vars).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- revert merge of PR #110 to restore theme-aware overlay and highlight colors
- ensure theme variables for accent, ok and border are reapplied when theme loads

## Testing
- `npm test` *(fails: diverging inclusive gateway auto forwards when only one condition matches, non-interrupting message boundary can trigger multiple times, call activity invokes called process, multi-instance subprocess waits for all instances, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f7c29cc48328bb9396e7370514e9