### PR TITLE
Revert PR #108: drop connection halo feature.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1109,20 +1109,14 @@ currentTheme.subscribe(theme => {
     }
 
     /* ── connections & arrows ───────────────────────────────────────────── */
-    .djs-connection .djs-visual {
+    .djs-connection .djs-connection-inner,
+    .djs-connection .djs-connection-outer {
       stroke: ${bpmn.connection.stroke} !important;
       stroke-width: ${bpmn.connection.strokeWidth}px !important;
     }
-    .djs-connection .djs-outline {
-      visibility: visible !important;
-      display: block !important;
-      stroke: ${bpmn.connectionOuter || colors.background} !important;
-      stroke-width: ${bpmn.connection.strokeWidth + 2}px !important;
-    }
     .djs-connection .djs-marker {
-      fill: ${bpmn.marker.fill};
-      stroke: ${bpmn.markerOutline || colors.background};
-      stroke-width: 1px;
+      fill: ${bpmn.marker.fill} !important;
+      stroke: ${bpmn.marker.stroke} !important;
     }
 
     /* ── selected styles ───────────────────────────────────────────────── */

--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -27,8 +27,6 @@
         "fill": "#d1b6ff",
         "stroke": "#d1b6ff"
       },
-      "connectionOuter": "#121212",
-      "markerOutline": "#121212",
       "label": {
         "fontFamily": "system-ui, sans-serif",
         "fill": "#bb86fc"
@@ -145,8 +143,6 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
-      "connectionOuter": "#0a192f",
-      "markerOutline": "#0a192f",
       "label": {
         "fontFamily": "Roboto, sans-serif",
         "fill": "#00ffcc"
@@ -205,8 +201,6 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
-      "connectionOuter": "#002b36",
-      "markerOutline": "#002b36",
       "label": {
         "fontFamily": "Arial, sans-serif",
         "fill": "#00ffcc"
@@ -323,8 +317,6 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
-      "connectionOuter": "#2e3d29",
-      "markerOutline": "#2e3d29",
       "label": {
         "fontFamily": "Verdana, sans-serif",
         "fill": "#00ffcc"
@@ -441,8 +433,6 @@
         "fill": "#64ffda",
         "stroke": "#64ffda"
       },
-      "connectionOuter": "#1a1a2e",
-      "markerOutline": "#1a1a2e",
       "label": {
         "fontFamily": "Helvetica Neue, sans-serif",
         "fill": "#00ffcc"
@@ -559,8 +549,6 @@
         "fill": "#00bfa5",
         "stroke": "#00bfa5"
       },
-      "connectionOuter": "#000000",
-      "markerOutline": "#000000",
       "label": {
         "fontFamily": "\"Share Tech Mono\", monospace",
         "fill": "#00ff00"


### PR DESCRIPTION
## Summary
- revert PR #108 to remove connection halo support
- prune connection halo fields from theme definitions

## Testing
- `npm test` *(fails: diverging inclusive gateway auto forwards when only one condition matches; non-interrupting message boundary can trigger multiple times; call activity invokes called process; multi-instance subprocess waits for all instances)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fa75fd008328a269cb7fa95c6357