### PR TITLE
Refactor app bootstrap into dedicated modules

### DIFF
--- a/public/js/app/addons.js
+++ b/public/js/app/addons.js
@@ -1,0 +1,66 @@
+import { avatarDropdown } from '../components/index.js';
+import { initAddOnOverlays } from '../addOnOverlays.js';
+import { initAddOnFiltering } from '../addOnFiltering.js';
+
+export function initializeAddOnServices({
+  overlays,
+  elementRegistry,
+  modeling,
+  canvas,
+  currentTheme,
+  addOnStore,
+  diagramXMLStream,
+  typeIcons
+}) {
+  const { scheduleOverlayUpdate } = initAddOnOverlays({
+    overlays,
+    elementRegistry,
+    typeIcons
+  });
+
+  const filteringApi = initAddOnFiltering({
+    currentTheme,
+    elementRegistry,
+    modeling,
+    canvas,
+    scheduleOverlayUpdate,
+    addOnStore,
+    diagramXMLStream,
+    typeIcons
+  });
+
+  return {
+    scheduleOverlayUpdate,
+    ...filteringApi
+  };
+}
+
+export function setupAvatarMenu({
+  avatarStream,
+  avatarOptions,
+  currentTheme,
+  buildDropdownOptions,
+  diagramDataStream
+}) {
+  let avatarMenu = avatarDropdown(avatarStream, avatarOptions, currentTheme, buildDropdownOptions());
+
+  function rebuildMenu() {
+    const newMenu = avatarDropdown(avatarStream, avatarOptions, currentTheme, buildDropdownOptions());
+    if (avatarMenu && avatarMenu.parentNode) {
+      avatarMenu.parentNode.replaceChild(newMenu, avatarMenu);
+    }
+    avatarMenu = newMenu;
+    return avatarMenu;
+  }
+
+  if (diagramDataStream?.subscribe) {
+    diagramDataStream.subscribe(() => rebuildMenu());
+  }
+
+  return {
+    get avatarMenu() {
+      return avatarMenu;
+    },
+    rebuildMenu
+  };
+}

--- a/public/js/app/init.js
+++ b/public/js/app/init.js
@@ -1,0 +1,91 @@
+import { applyThemeToPage } from '../core/theme.js';
+
+function setupHelpGuide(currentTheme) {
+  const helpGuideEl = document.getElementById('help-guide');
+
+  window.openHelpGuideModal = () => {
+    if (!helpGuideEl) return;
+    helpGuideEl.hidden = false;
+  };
+
+  if (!helpGuideEl) {
+    return;
+  }
+
+  const iframe = helpGuideEl.querySelector('iframe');
+  if (iframe) {
+    const applyIframeTheme = () => {
+      const body = iframe.contentDocument?.body;
+      if (!body) return;
+
+      applyThemeToPage(currentTheme.get(), body);
+      currentTheme.subscribe(theme => applyThemeToPage(theme, body));
+    };
+
+    if (iframe.contentDocument?.readyState === 'complete') {
+      applyIframeTheme();
+    }
+
+    iframe.addEventListener('load', applyIframeTheme);
+  }
+
+  const helpGuideCloseBtn = document.getElementById('help-guide-close');
+  if (helpGuideCloseBtn) {
+    helpGuideCloseBtn.addEventListener('click', () => {
+      helpGuideEl.hidden = true;
+    });
+  }
+
+  helpGuideEl.addEventListener('click', e => {
+    if (e.target === helpGuideEl) helpGuideEl.hidden = true;
+  });
+}
+
+function setupTouchHandling() {
+  document.addEventListener(
+    'touchmove',
+    e => {
+      if (!e.target.closest('.djs-container')) {
+        e.preventDefault();
+      }
+    },
+    { passive: false }
+  );
+}
+
+export function setupPageScaffolding({ currentTheme }) {
+  Object.assign(document.body.style, {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100vh',
+    margin: '0'
+  });
+
+  setupHelpGuide(currentTheme);
+  setupTouchHandling();
+
+  const canvasEl = document.getElementById('canvas');
+  if (!canvasEl) {
+    throw new Error('Canvas element not found');
+  }
+
+  const header = document.querySelector('header');
+
+  document.body.appendChild(canvasEl);
+
+  return { canvasEl, header };
+}
+
+export function createHiddenFileInput({ accept, onChange }) {
+  const input = document.createElement('input');
+  input.type = 'file';
+  if (accept) {
+    input.accept = accept;
+  }
+  input.style.display = 'none';
+  if (onChange) {
+    input.addEventListener('change', onChange);
+  }
+  document.body.appendChild(input);
+  return input;
+}

--- a/public/js/app/overlay.js
+++ b/public/js/app/overlay.js
@@ -1,0 +1,50 @@
+import { createDiagramOverlay } from '../components/index.js';
+
+export const typeIcons = {
+  'Knowledge': '📚',
+  'Business': '💼',
+  'Requirement': '📝',
+  'Lifecycle': '🔄',
+  'Measurement': '📊',
+  'Condition': '⚖️',
+  'Material': '🧱',
+  'Role': '👤',
+  'Equipment': '🛠️',
+  'System': '⚙️',
+  'Tool': '🧰',
+  'Information': 'ℹ️'
+};
+
+window.typeIcons = typeIcons;
+
+export function createOverlay({ nameStream, versionStream, currentTheme }) {
+  return createDiagramOverlay(nameStream, versionStream, currentTheme);
+}
+
+export function setupCanvasLayout({ canvasEl, header, currentTheme }) {
+  const setCanvasHeight = () => {
+    if (!header) return;
+    canvasEl.style.height = `calc(100vh - ${header.offsetHeight}px)`;
+  };
+
+  Object.assign(canvasEl.style, {
+    flex: '1 1 auto',
+    width: '100%',
+    border: `1px solid ${currentTheme.get().colors.border}`
+  });
+
+  setCanvasHeight();
+  window.addEventListener('resize', setCanvasHeight);
+
+  return () => window.removeEventListener('resize', setCanvasHeight);
+}
+
+export function attachOverlay(overlayEl) {
+  const container = document.querySelector('.bjs-container') || document.getElementById('canvas');
+  if (!container) return null;
+  if (!container.style.position) {
+    container.style.position = 'relative';
+  }
+  container.appendChild(overlayEl);
+  return container;
+}

--- a/public/js/app/simulation.js
+++ b/public/js/app/simulation.js
@@ -1,0 +1,102 @@
+import { createSimulation } from '../core/simulation.js';
+import { createTokenListPanel } from '../components/tokenListPanel.js';
+import { openFlowSelectionModal } from '../components/index.js';
+import { Blockchain } from '../blockchain.js';
+
+export function bootstrapSimulation({ modeler, currentTheme }) {
+  const elementRegistry = modeler.get('elementRegistry');
+  const canvas = modeler.get('canvas');
+  const simulation = createSimulation({ elementRegistry, canvas });
+  window.simulation = simulation;
+
+  const tokenPanel = createTokenListPanel(simulation.tokenLogStream, currentTheme);
+  document.body.appendChild(tokenPanel.el);
+
+  if (simulation.tokenLogStream.get().length) {
+    tokenPanel.show();
+  }
+
+  let blockchain;
+  let processedTokens = 0;
+  let blockchainPersistPromise = Promise.resolve();
+
+  function initBlockchain() {
+    tokenPanel.hide();
+    blockchain = new Blockchain();
+    tokenPanel.setBlockchain?.(blockchain);
+    processedTokens = 0;
+  }
+
+  const origStart = simulation.start;
+  simulation.start = (...args) => {
+    initBlockchain();
+    tokenPanel.show();
+    return origStart.apply(simulation, args);
+  };
+
+  const origReset = simulation.reset;
+  simulation.reset = (...args) => {
+    initBlockchain();
+    return origReset.apply(simulation, args);
+  };
+
+  if (tokenPanel.setDownloadHandler) {
+    tokenPanel.setDownloadHandler(() => {
+      const data = JSON.stringify(blockchain?.chain ?? [], null, 2);
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'blockchain.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    });
+  }
+
+  simulation.tokenLogStream.subscribe(entries => {
+    if (entries.length) {
+      tokenPanel.show();
+    } else {
+      tokenPanel.hide();
+    }
+
+    if (blockchain && entries.length > processedTokens) {
+      const toPersist = entries.slice(processedTokens);
+      blockchainPersistPromise = blockchainPersistPromise.then(() => {
+        for (let i = 0; i < toPersist.length; i++) {
+          blockchain.addBlock(toPersist[i]);
+        }
+        processedTokens = entries.length;
+        window.dispatchEvent(new Event('blockchain-persisted'));
+      });
+    }
+  });
+
+  let prevTokenCount = simulation.tokenStream.get().length;
+  simulation.tokenStream.subscribe(tokens => {
+    if (prevTokenCount > 0 && tokens.length === 0) {
+      tokenPanel.show();
+      blockchainPersistPromise.then(() => tokenPanel.showDownload());
+    }
+    prevTokenCount = tokens.length;
+  });
+
+  simulation.pathsStream.subscribe(data => {
+    if (!data) return;
+    const { flows, type } = data;
+    if (!flows || !flows.length) return;
+    const allowMultiple = type === 'bpmn:InclusiveGateway';
+    openFlowSelectionModal(flows, currentTheme, allowMultiple).subscribe(selection => {
+      if (!selection) return;
+      if (Array.isArray(selection)) {
+        if (selection.length) simulation.step(selection.map(f => f.id));
+      } else {
+        simulation.step(selection.id);
+      }
+    });
+  });
+
+  return { simulation, tokenPanel };
+}


### PR DESCRIPTION
## Summary
- factor UI scaffolding, overlay helpers, add-on wiring, and simulation bootstrap into dedicated modules under public/js/app
- streamline app.js to orchestrate imported modules and keep global streams exported
- update file input handling and overlay attachment to consume the new helpers

## Testing
- npm test *(fails: existing simulation suite expectations; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c97a15a9508328a341dc261fcfab21