### PR TITLE
Refactor property configuration and RACI helpers

### DIFF
--- a/public/js/components/property-config.js
+++ b/public/js/components/property-config.js
@@ -1,0 +1,271 @@
+export const BPMN_PROPERTY_MAP = {
+  'bpmn:Task': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:UserTask': [
+    'name', 'documentation', 'assignee',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings', 'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:ServiceTask': [
+    'name', 'documentation', 'implementation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:ScriptTask': [
+    'name', 'documentation', 'script', 'scriptFormat',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:CallActivity': [
+    'name', 'documentation', 'calledElement',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings', 'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:SubProcess': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:StartEvent': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:EndEvent': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:IntermediateCatchEvent': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:IntermediateThrowEvent': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:BoundaryEvent': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:ExclusiveGateway': [
+    'name', 'documentation', 'default',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:InclusiveGateway': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:ParallelGateway': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:ComplexGateway': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:EventBasedGateway': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'variables', 'inputMappings', 'outputMappings',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:SequenceFlow': [
+    'name', 'documentation', 'conditionExpression',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:DataObjectReference': [
+    'name', 'itemSubjectRef',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:DataStoreReference': [
+    'name', 'itemSubjectRef',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:Participant': [
+    'name', 'processRef',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:Lane': [
+    'name',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:TextAnnotation': [
+    'text',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:Group': [
+    'name', 'categoryValueRef',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:Message': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:Signal': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:Error': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:Escalation': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ],
+  'bpmn:EndPoint': [
+    'name', 'documentation',
+    'estimatedDuration', 'actualDuration',
+    'costEstimate', 'ownerRole',
+    'inputQuality', 'outputQuality',
+    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
+    'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
+  ]
+};
+
+export const FIELD_DEFINITIONS = [
+  { key: 'name',              label: 'Name',                type: 'text' },
+  { key: 'documentation',     label: 'Documentation',       type: 'textarea' },
+  { key: 'assignee',          label: 'Assignee',            type: 'text' },
+  { key: 'calledElement',     label: 'Called Element',      type: 'text' },
+  { key: 'script',            label: 'Script Content',      type: 'textarea' },
+  { key: 'scriptFormat',      label: 'Script Format',       type: 'text' },
+  { key: 'implementation',    label: 'Implementation',      type: 'text' },
+  { key: 'default',           label: 'Default Flow ID',     type: 'text' },
+  { key: 'conditionExpression', label: 'Condition (for flow)', type: 'textarea' },
+  { key: 'variables',        label: 'Variables',           type: 'array' },
+  { key: 'inputMappings',    label: 'Input Mappings',      type: 'array' },
+  { key: 'outputMappings',   label: 'Output Mappings',     type: 'array' },
+  { key: 'itemSubjectRef',    label: 'Data Type (ItemRef)', type: 'text' },
+  { key: 'processRef',        label: 'Linked Process ID',   type: 'text' },
+  { key: 'text',              label: 'Annotation Text',     type: 'textarea' },
+  { key: 'processOwner',      label: 'Process Owner',       type: 'text' },
+  { key: 'creator',           label: 'Creator',             type: 'text' },
+  { key: 'categoryValueRef',  label: 'Category Reference',  type: 'text' },
+  { key: 'estimatedDuration',  label: 'Estimated Duration (mins)', type: 'text' },
+  { key: 'actualDuration',     label: 'Actual Duration (mins)',    type: 'text' },
+  { key: 'costEstimate',       label: 'Estimated Cost ($)',        type: 'text' },
+  { key: 'ownerRole',          label: 'Responsible Role',          type: 'text' },
+  { key: 'inputQuality',       label: 'Input Quality Score',       type: 'text' },
+  { key: 'outputQuality',      label: 'Output Quality Score',      type: 'text' },
+  { key: 'downTime',           label: 'Down Time',                 type: 'text' },
+  { key: 'upTime',             label: 'Up Time',                   type: 'text' },
+  { key: 'changeOverTime',     label: 'Change Over Time',          type: 'text' },
+  { key: 'perCompleteAccurate', label: 'Percent Complete and Accurate',          type: 'text' },
+  { key: 'availability ',       label: 'Availability',            type: 'text' },
+  { key: 'leadTime ',           label: 'Lead Time',               type: 'text' },
+  { key: 'kpiNotes',           label: 'KPI Notes',                 type: 'textarea' },
+  { key: 'responsible',       label: 'Responsible',             type: 'text' },
+  { key: 'accountable',       label: 'Accountable',             type: 'text' },
+  { key: 'consulted',         label: 'Consulted',               type: 'text' },
+  { key: 'informed',          label: 'Informed',                type: 'text' },
+];

--- a/public/js/components/raci.js
+++ b/public/js/components/raci.js
@@ -1,0 +1,97 @@
+export const RACI_FIELDS = ['responsible', 'accountable', 'consulted', 'informed'];
+const RACI_MRU_KEY = 'raciMru';
+const RACI_DATALIST_ID = 'raci-mru';
+const MAX_MRU_ENTRIES = 10;
+
+function loadMru() {
+  try {
+    const stored = localStorage.getItem(RACI_MRU_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveMru(values) {
+  try {
+    localStorage.setItem(RACI_MRU_KEY, JSON.stringify(values));
+  } catch (e) {
+    // ignore storage errors
+  }
+}
+
+function renderOptions(datalist, values = loadMru()) {
+  datalist.replaceChildren();
+  values.forEach(value => {
+    const option = document.createElement('option');
+    option.value = value;
+    datalist.appendChild(option);
+  });
+}
+
+function updateMru(value) {
+  if (!value) {
+    return loadMru();
+  }
+  let values = loadMru().filter(entry => entry !== value);
+  values.unshift(value);
+  if (values.length > MAX_MRU_ENTRIES) {
+    values = values.slice(0, MAX_MRU_ENTRIES);
+  }
+  saveMru(values);
+  return values;
+}
+
+function ensureExtensionElements(bo, moddle) {
+  if (!bo.extensionElements) {
+    bo.extensionElements = moddle.create('bpmn:ExtensionElements', { values: [] });
+  }
+  bo.extensionElements.values = bo.extensionElements.values || [];
+  return bo.extensionElements;
+}
+
+function ensureRaciElement(bo, moddle) {
+  const extEl = ensureExtensionElements(bo, moddle);
+  let raciEl = extEl.values.find(v => v.$type === 'custom:Raci');
+  if (!raciEl) {
+    raciEl = moddle.create('custom:Raci', {});
+    extEl.values.push(raciEl);
+  }
+  return raciEl;
+}
+
+export function createRaciDatalist() {
+  const datalist = document.createElement('datalist');
+  datalist.id = RACI_DATALIST_ID;
+  renderOptions(datalist);
+  return datalist;
+}
+
+export function attachRaciMruHandlers(input, datalist) {
+  input.setAttribute('list', RACI_DATALIST_ID);
+  const update = () => {
+    const list = updateMru(input.value.trim());
+    renderOptions(datalist, list);
+  };
+  input.addEventListener('change', update);
+  input.addEventListener('blur', update);
+}
+
+export function getRaciFieldValue(bo, key) {
+  const raci = (bo.extensionElements?.values || []).find(v => v.$type === 'custom:Raci');
+  return raci?.[key];
+}
+
+export function updateRaciAssignments(bo, attrs, formData, moddle) {
+  const raciEl = ensureRaciElement(bo, moddle);
+  RACI_FIELDS.forEach(field => {
+    const value = formData.get(field) || '';
+    if (value) {
+      attrs[field] = value;
+      raciEl[field] = value;
+    } else {
+      delete attrs[field];
+      delete raciEl[field];
+    }
+  });
+}

--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -2,246 +2,20 @@ import { Stream } from '../core/stream.js';
 import { currentTheme } from '../core/theme.js';
 import { reactiveButton, showConfirmationDialog } from './elements.js';
 import { divider, row } from './layout.js';
+import { BPMN_PROPERTY_MAP, FIELD_DEFINITIONS } from './property-config.js';
+import {
+  RACI_FIELDS,
+  createRaciDatalist,
+  attachRaciMruHandlers,
+  getRaciFieldValue,
+  updateRaciAssignments,
+} from './raci.js';
 
 // 1) Create the sidebar container (hidden by default)
 const propsSidebar = document.createElement('div');
 propsSidebar.classList.add('props-sidebar');
 document.body.appendChild(propsSidebar);
 
-const RACI_FIELDS = ['responsible', 'accountable', 'consulted', 'informed'];
-const RACI_MRU_KEY = 'raciMru';
-
-const BPMN_PROPERTY_MAP = {
-  'bpmn:Task': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:UserTask': [
-    'name', 'documentation', 'assignee',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 'variables', 'inputMappings', 'outputMappings', 'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:ServiceTask': [
-    'name', 'documentation', 'implementation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:ScriptTask': [
-    'name', 'documentation', 'script', 'scriptFormat',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:CallActivity': [
-    'name', 'documentation', 'calledElement',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 'variables', 'inputMappings', 'outputMappings', 'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:SubProcess': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:StartEvent': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',   'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:EndEvent': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:IntermediateCatchEvent': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:IntermediateThrowEvent': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:BoundaryEvent': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',   'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:ExclusiveGateway': [
-    'name', 'documentation', 'default',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:InclusiveGateway': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:ParallelGateway': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:ComplexGateway': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:EventBasedGateway': [
-    'name', 'documentation',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime',
-  'variables', 'inputMappings', 'outputMappings',
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:SequenceFlow': [
-    'name', 'documentation', 'conditionExpression',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:DataObjectReference': [
-    'name', 'itemSubjectRef',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:DataStoreReference': [
-    'name', 'itemSubjectRef',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:Participant': [
-    'name', 'processRef',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:Lane': [
-    'name',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:TextAnnotation': [
-    'text',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-    'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ],
-  'bpmn:Group': [
-    'name', 'categoryValueRef',
-    'estimatedDuration', 'actualDuration',
-  'costEstimate', 'ownerRole',
-  'inputQuality', 'outputQuality',
-  'processOwner', 'creator', 'downTime', 'upTime', 'changeOverTime', 'perCompleteAccurate', 'availability', 'leadTime', 
-  'kpiNotes', 'responsible', 'accountable', 'consulted', 'informed'
-  ]
-};
-
-
-  const FIELD_DEFINITIONS = [
-  { key: 'name',              label: 'Name',                type: 'text' },
-  { key: 'documentation',     label: 'Documentation',       type: 'textarea' },
-  { key: 'assignee',          label: 'Assignee',            type: 'text' },
-  { key: 'calledElement',     label: 'Called Element',      type: 'text' },
-  { key: 'script',            label: 'Script Content',      type: 'textarea' },
-  { key: 'scriptFormat',      label: 'Script Format',       type: 'text' },
-  { key: 'implementation',    label: 'Implementation',      type: 'text' },
-  { key: 'default',           label: 'Default Flow ID',     type: 'text' },
-  { key: 'conditionExpression', label: 'Condition (for flow)', type: 'textarea' },
-  { key: 'variables',        label: 'Variables',           type: 'array' },
-  { key: 'inputMappings',    label: 'Input Mappings',      type: 'array' },
-  { key: 'outputMappings',   label: 'Output Mappings',     type: 'array' },
-  { key: 'itemSubjectRef',    label: 'Data Type (ItemRef)', type: 'text' },
-  { key: 'processRef',        label: 'Linked Process ID',   type: 'text' },
-  { key: 'text',              label: 'Annotation Text',     type: 'textarea' },
-  { key: 'processOwner',      label: 'Process Owner',       type: 'text' },
-  { key: 'creator',           label: 'Creator',             type: 'text' },
-  { key: 'categoryValueRef',  label: 'Category Reference',  type: 'text' },
-  { key: 'estimatedDuration',  label: 'Estimated Duration (mins)', type: 'text' },
-  { key: 'actualDuration',     label: 'Actual Duration (mins)',    type: 'text' },
-  { key: 'costEstimate',       label: 'Estimated Cost ($)',        type: 'text' },
-  { key: 'ownerRole',          label: 'Responsible Role',          type: 'text' },
-  { key: 'inputQuality',       label: 'Input Quality Score',       type: 'text' },
-  { key: 'outputQuality',      label: 'Output Quality Score',      type: 'text' },
-  { key: 'downTime',           label: 'Down Time',                 type: 'text' },
-  { key: 'upTime',             label: 'Up Time',                   type: 'text' },
-  { key: 'changeOverTime',     label: 'Change Over Time',          type: 'text' },
-  { key: 'perCompleteAccurate', label: 'Percent Complete and Accurate',          type: 'text' },
-  { key: 'availability ',       label: 'Availability',            type: 'text' },
-  { key: 'leadTime ',           label: 'Lead Time',               type: 'text' },
-  { key: 'kpiNotes',           label: 'KPI Notes',                 type: 'textarea' },
-  { key: 'responsible',       label: 'Responsible',             type: 'text' },
-  { key: 'accountable',       label: 'Accountable',             type: 'text' },
-  { key: 'consulted',         label: 'Consulted',               type: 'text' },
-  { key: 'informed',          label: 'Informed',                type: 'text' },
-
-];
 
 function openUrlModal(url) {
   const modal = document.createElement('div');
@@ -312,18 +86,7 @@ export function showProperties(element, modeling, moddle) {
 
   const form = document.createElement('form');
 
-  const raciDatalist = document.createElement('datalist');
-  raciDatalist.id = 'raci-mru';
-  let raciMru = JSON.parse(localStorage.getItem(RACI_MRU_KEY) || '[]');
-  function renderRaciOptions() {
-    raciDatalist.replaceChildren();
-    raciMru.forEach(v => {
-      const opt = document.createElement('option');
-      opt.value = v;
-      raciDatalist.appendChild(opt);
-    });
-  }
-  renderRaciOptions();
+  const raciDatalist = createRaciDatalist();
   form.appendChild(raciDatalist);
 
   // Local AddOns array
@@ -552,23 +315,7 @@ export function showProperties(element, modeling, moddle) {
 
       modeling.updateProperties(element, props);
 
-      const raciKeys = RACI_FIELDS;
-      let raciEl = (bo.extensionElements?.values || []).find(v => v.$type === 'custom:Raci');
-      if (!raciEl) {
-        const extEl = getOrCreateExtEl(bo, moddle);
-        raciEl = moddle.create('custom:Raci', {});
-        extEl.values.push(raciEl);
-      }
-      raciKeys.forEach(k => {
-        const v = data.get(k) || '';
-        if (v) {
-          attrs[k] = v;
-          raciEl[k] = v;
-        } else {
-          delete attrs[k];
-          delete raciEl[k];
-        }
-      });
+      updateRaciAssignments(bo, attrs, data, moddle);
 
       // handle array-based custom elements
       const extEl = getOrCreateExtEl(bo, moddle);
@@ -803,8 +550,7 @@ export function showProperties(element, modeling, moddle) {
       val = attrs?.[key];
     }
     if (val == null && RACI_FIELDS.includes(key)) {
-      const raci = (bo.extensionElements?.values || []).find(v => v.$type === 'custom:Raci');
-      val = raci?.[key];
+      val = getRaciFieldValue(bo, key);
     }
     if (val == null) {
       const extEl = bo.extensionElements;
@@ -840,20 +586,7 @@ export function showProperties(element, modeling, moddle) {
     }
 
     if (RACI_FIELDS.includes(key)) {
-      input.setAttribute('list', 'raci-mru');
-      const updateRaciMru = () => {
-        const value = input.value.trim();
-        if (!value) return;
-        let mru = JSON.parse(localStorage.getItem(RACI_MRU_KEY) || '[]');
-        mru = mru.filter(v => v !== value);
-        mru.unshift(value);
-        if (mru.length > 10) mru = mru.slice(0, 10);
-        localStorage.setItem(RACI_MRU_KEY, JSON.stringify(mru));
-        raciMru = mru;
-        renderRaciOptions();
-      };
-      input.addEventListener('change', updateRaciMru);
-      input.addEventListener('blur', updateRaciMru);
+      attachRaciMruHandlers(input, raciDatalist);
     }
 
     wrapper.appendChild(input);


### PR DESCRIPTION
## Summary
- extract the BPMN property map and field definitions into a reusable property-config module
- move RACI MRU handling and extension helpers into a dedicated raci module
- update showProperties to reference the new modules while keeping sidebar rendering in place

## Testing
- npm test *(fails: existing inclusive gateway, simulation, and event handler assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68c97fcecf0c8328a4c26279dcbcbcfa