### PR TITLE
Refactor simulation helpers into modules

### DIFF
--- a/public/js/core/simulation/context.js
+++ b/public/js/core/simulation/context.js
@@ -1,0 +1,13 @@
+export function createContextHelpers({ getTokens }) {
+  function setContext(obj, token = getTokens()[0]) {
+    if (token) {
+      token.context = { ...(token.context || {}), ...obj };
+    }
+  }
+
+  function getContext(token = getTokens()[0]) {
+    return token ? { ...(token.context || {}) } : {};
+  }
+
+  return { setContext, getContext };
+}

--- a/public/js/core/simulation/handlers.js
+++ b/public/js/core/simulation/handlers.js
@@ -1,0 +1,42 @@
+export function createHandlerManager() {
+  const elementHandlers = new Map();
+  const handlerCleanups = new Set();
+  const skipHandlerFor = new Set();
+
+  function addHandlerCleanup(fn) {
+    handlerCleanups.add(fn);
+  }
+
+  function runCleanups() {
+    handlerCleanups.forEach(fn => fn());
+    handlerCleanups.clear();
+  }
+
+  function markHandlerSkip(tokenId) {
+    skipHandlerFor.add(tokenId);
+  }
+
+  function clearHandlerSkip(tokenId) {
+    skipHandlerFor.delete(tokenId);
+  }
+
+  function shouldSkipHandler(tokenId) {
+    return skipHandlerFor.has(tokenId);
+  }
+
+  function clearHandlerState(clearSkip = false) {
+    runCleanups();
+    if (clearSkip) {
+      skipHandlerFor.clear();
+    }
+  }
+
+  return {
+    elementHandlers,
+    addHandlerCleanup,
+    clearHandlerState,
+    markHandlerSkip,
+    clearHandlerSkip,
+    shouldSkipHandler
+  };
+}

--- a/public/js/core/simulation/token-log.js
+++ b/public/js/core/simulation/token-log.js
@@ -1,0 +1,55 @@
+const TOKEN_LOG_STORAGE_KEY = 'simulationTokenLog';
+
+export function createTokenLogHelpers({
+  tokenLogStream,
+  tokenStream,
+  elementRegistry,
+  getInitialContext,
+  setTokens
+}) {
+  function saveTokenLog() {
+    try {
+      const data = tokenLogStream.get();
+      if (data && data.length) {
+        localStorage.setItem(TOKEN_LOG_STORAGE_KEY, JSON.stringify(data));
+      } else {
+        localStorage.removeItem(TOKEN_LOG_STORAGE_KEY);
+      }
+    } catch (err) {
+      console.warn('Failed to save token log', err);
+    }
+  }
+
+  function loadTokenLog() {
+    try {
+      const data = localStorage.getItem(TOKEN_LOG_STORAGE_KEY);
+      if (data) {
+        const parsed = JSON.parse(data);
+        tokenLogStream.set(parsed);
+        if (parsed.length) {
+          const last = parsed[parsed.length - 1];
+          if (last.elementId) {
+            const el = elementRegistry.get(last.elementId);
+            if (el) {
+              const tokens = [
+                { id: last.tokenId, element: el, context: { ...getInitialContext() } }
+              ];
+              setTokens(tokens);
+              tokenStream.set(tokens);
+            }
+          }
+        }
+        saveTokenLog();
+      }
+    } catch (err) {
+      console.warn('Failed to load token log', err);
+    }
+  }
+
+  function clearTokenLog() {
+    tokenLogStream.set([]);
+    saveTokenLog();
+  }
+
+  return { saveTokenLog, loadTokenLog, clearTokenLog };
+}


### PR DESCRIPTION
## Summary
- extract simulation context getters/setters into public/js/core/simulation/context.js
- extract element handler management and cleanup into public/js/core/simulation/handlers.js
- extract token log persistence helpers into public/js/core/simulation/token-log.js and wire them into createSimulation

## Testing
- npm test *(fails due to existing simulation assertions in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c98513b2fc832882e09aaffa5f0f7a