### PR TITLE
Fix showProperties button import after components split

### DIFF
--- a/public/js/components/showProperties.js
+++ b/public/js/components/showProperties.js
@@ -1,6 +1,6 @@
 import { Stream } from '../core/stream.js';
 import { currentTheme } from '../core/theme.js';
-import { reactiveButton, showConfirmationDialog } from './elements.js';
+import { reactiveButton, showConfirmationDialog } from './controls.js';
 import { divider, row } from './layout.js';
 import { BPMN_PROPERTY_MAP, FIELD_DEFINITIONS } from './property-config.js';
 import {


### PR DESCRIPTION
## Summary
- update showProperties to import reactiveButton and showConfirmationDialog from the new controls module

## Testing
- not run (UI fix only)


------
https://chatgpt.com/codex/tasks/task_e_68c967ecaac88328b80ad40a586d4183