### PR TITLE
Add interactive timeline waypoint stream

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -16,6 +16,7 @@ import { doc, collection, updateDoc, setDoc, addDoc, getDoc, Timestamp, arrayUni
 import { setupPageScaffolding, createHiddenFileInput } from './app/init.js';
 import { typeIcons, createOverlay, setupCanvasLayout, attachOverlay } from './app/overlay.js';
 import { setupTimeline } from './app/timeline.js';
+import { updateTimelineEntry } from './modules/timeline.js';
 import { initializeAddOnServices, setupAvatarMenu } from './app/addons.js';
 import { bootstrapSimulation } from './app/simulation.js';
 // Initialization function will handle dynamic imports and DOM setup later.
@@ -121,7 +122,24 @@ setupCanvasLayout({ canvasEl, header, currentTheme });
   const eventBus        = modeler.get('eventBus');
   const overlays        = modeler.get('overlays');
 
-  setupTimeline({ canvas, eventBus, elementRegistry });
+  setupTimeline({
+    canvas,
+    eventBus,
+    elementRegistry,
+    onEditEntry(entry) {
+      const initialName = entry.metadata?.name ?? entry.label ?? '';
+      const initialNotes = entry.metadata?.notes ?? '';
+
+      promptDiagramMetadata(initialName, initialNotes, currentTheme).subscribe(metadata => {
+        if (!metadata) return;
+
+        updateTimelineEntry(entry.id, {
+          label: metadata.name?.trim() || entry.label || '',
+          metadata: { ...entry.metadata, ...metadata }
+        });
+      });
+    }
+  });
 
   const { simulation } = bootstrapSimulation({ modeler, currentTheme });
 

--- a/public/js/app/timeline.js
+++ b/public/js/app/timeline.js
@@ -1,4 +1,20 @@
+import {
+  timelineEntries,
+  addTimelineEntry,
+  updateTimelineEntry,
+  selectTimelineEntry,
+  selectedTimelineEntryId,
+  getTimelineEntry
+} from '../modules/timeline.js';
+
 const SVG_NS = 'http://www.w3.org/2000/svg';
+const MARKER_RADIUS = 6;
+const DEFAULT_COLOR = '#2b6cb0';
+const DEFAULT_STROKE = '#1a365d';
+const SELECTED_COLOR = '#ed8936';
+const SELECTED_STROKE = '#c05621';
+
+const clamp = (value, min = 0, max = 1) => Math.min(Math.max(value, min), max);
 
 function createSvgElement(tagName, attributes = {}) {
   const element = document.createElementNS(SVG_NS, tagName);
@@ -15,25 +31,49 @@ function ensureTimelineGroup(layer) {
 
   if (!group) {
     group = createSvgElement('g', { class: 'djs-timeline' });
+    group.style.pointerEvents = 'auto';
     layer.appendChild(group);
   }
 
   return group;
 }
 
-export function setupTimeline({ canvas, eventBus }) {
+function dispatchTimelineEvent(type, detail) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(type, { detail }));
+}
+
+export function setupTimeline({ canvas, eventBus, onEditEntry } = {}) {
   const layer = canvas.getLayer('timeline', 1000);
   const timelineGroup = ensureTimelineGroup(layer);
 
-  function clearGroup() {
-    while (timelineGroup.firstChild) {
-      timelineGroup.removeChild(timelineGroup.firstChild);
-    }
-  }
+  const axis = createSvgElement('line', {
+    class: 'djs-timeline-axis',
+    x1: 0,
+    y1: 0,
+    x2: 0,
+    y2: 0,
+    stroke: '#4a5568',
+    'stroke-width': '2',
+    'stroke-linecap': 'round'
+  });
+  axis.style.cursor = 'crosshair';
+  axis.style.touchAction = 'none';
 
-  function drawTimeline() {
+  const markersGroup = createSvgElement('g', { class: 'djs-timeline-markers' });
+
+  timelineGroup.appendChild(axis);
+  timelineGroup.appendChild(markersGroup);
+
+  const markerElements = new Map();
+
+  let axisLength = 0;
+
+  function updateLayout() {
     const root = canvas.getRootElement();
     if (!root) {
+      axisLength = 0;
+      timelineGroup.style.display = 'none';
       return;
     }
 
@@ -43,67 +83,234 @@ export function setupTimeline({ canvas, eventBus }) {
     }
 
     const bounds = rootGfx.getBBox();
-    const width = Math.max(bounds.width, 1);
-    const translateX = bounds.x;
-    const translateY = bounds.y + bounds.height + 30;
+    axisLength = Math.max(bounds.width, 1);
 
     if (!timelineGroup.isConnected) {
       layer.appendChild(timelineGroup);
     }
 
-    timelineGroup.setAttribute('transform', `translate(${translateX}, ${translateY})`);
+    timelineGroup.style.display = 'block';
+    timelineGroup.setAttribute('transform', `translate(${bounds.x}, ${bounds.y + bounds.height + 30})`);
+    axis.setAttribute('x1', 0);
+    axis.setAttribute('y1', 0);
+    axis.setAttribute('x2', axisLength);
+    axis.setAttribute('y2', 0);
 
-    clearGroup();
+    renderMarkers(timelineEntries.get());
+  }
 
-    const axis = createSvgElement('line', {
-      x1: 0,
-      y1: 0,
-      x2: width,
-      y2: 0,
-      stroke: '#4a5568',
-      'stroke-width': '2',
-      'stroke-linecap': 'round'
+  function getLocalX(event) {
+    const svg = axis.ownerSVGElement;
+    if (!svg) return null;
+    const point = svg.createSVGPoint();
+    point.x = event.clientX;
+    point.y = event.clientY;
+
+    const matrix = axis.getScreenCTM();
+    if (!matrix) return null;
+    const local = point.matrixTransform(matrix.inverse());
+    return clamp(local.x, 0, axisLength);
+  }
+
+  function updateSelection(selectedId) {
+    markerElements.forEach(({ group, circle }) => {
+      if (group.dataset.entryId === selectedId) {
+        group.classList.add('is-selected');
+        circle.setAttribute('fill', SELECTED_COLOR);
+        circle.setAttribute('stroke', SELECTED_STROKE);
+      } else {
+        group.classList.remove('is-selected');
+        const entry = getTimelineEntry(group.dataset.entryId);
+        const fill = entry?.color || DEFAULT_COLOR;
+        circle.setAttribute('fill', fill);
+        circle.setAttribute('stroke', DEFAULT_STROKE);
+      }
+    });
+  }
+
+  function updateMarker(entry, index, elements) {
+    const offset = clamp(entry.offset ?? 0);
+    const positionX = axisLength * offset;
+
+    elements.group.setAttribute('transform', `translate(${positionX}, 0)`);
+    const labelText = entry.label?.trim() || `T${index + 1}`;
+    elements.label.textContent = labelText;
+
+    const fillColor = entry.color || DEFAULT_COLOR;
+    elements.circle.setAttribute('fill', fillColor);
+  }
+
+  function renderMarkers(entries) {
+    const ids = new Set(entries.map(entry => entry.id));
+
+    Array.from(markerElements.keys())
+      .filter(id => !ids.has(id))
+      .forEach(id => {
+        const elements = markerElements.get(id);
+        if (elements) {
+          elements.group.remove();
+          markerElements.delete(id);
+        }
+      });
+
+    entries.forEach((entry, index) => {
+      let elements = markerElements.get(entry.id);
+      if (!elements) {
+        elements = createMarker(entry.id);
+        markerElements.set(entry.id, elements);
+        markersGroup.appendChild(elements.group);
+      }
+
+      updateMarker(entry, index, elements);
     });
 
-    timelineGroup.appendChild(axis);
+    updateSelection(selectedTimelineEntryId.get());
+  }
 
-    const slotCount = 5;
-    const step = slotCount > 1 ? width / (slotCount - 1) : width;
+  const dragState = {
+    id: null,
+    pointerId: null,
+    hasMoved: false,
+    startX: 0
+  };
 
-    for (let i = 0; i < slotCount; i += 1) {
-      const positionX = Math.min(step * i, width);
+  function finishDrag(event) {
+    if (!dragState.id || dragState.pointerId !== event.pointerId) {
+      return;
+    }
 
-      const slot = createSvgElement('circle', {
-        cx: positionX,
-        cy: 0,
-        r: 6,
-        fill: '#2b6cb0',
-        stroke: '#1a365d',
-        'stroke-width': '1'
-      });
+    const marker = markerElements.get(dragState.id);
+    if (marker) {
+      marker.group.releasePointerCapture(event.pointerId);
+    }
 
-      const label = createSvgElement('text', {
-        x: positionX,
-        y: 20,
-        'text-anchor': 'middle',
-        'font-size': '12',
-        fill: '#2d3748'
-      });
+    const entry = getTimelineEntry(dragState.id);
+    const wasMoved = dragState.hasMoved;
 
-      label.textContent = `T${i + 1}`;
+    dragState.id = null;
+    dragState.pointerId = null;
+    dragState.hasMoved = false;
+    dragState.startX = 0;
 
-      timelineGroup.appendChild(slot);
-      timelineGroup.appendChild(label);
+    if (!wasMoved && entry) {
+      requestEdit(entry.id, 'select');
+    } else if (entry) {
+      dispatchTimelineEvent('timeline:moved', { entry });
     }
   }
 
-  drawTimeline();
+  function attachMarkerInteraction(elements, id) {
+    const { group } = elements;
+    group.style.cursor = 'pointer';
+    group.style.touchAction = 'none';
 
-  eventBus.on('import.done', drawTimeline);
-  eventBus.on('canvas.viewbox.changed', drawTimeline);
-  eventBus.on('commandStack.changed', drawTimeline);
+    group.addEventListener('pointerdown', event => {
+      if (event.button !== 0) return;
+      event.stopPropagation();
+
+      selectTimelineEntry(id);
+      dispatchTimelineEvent('timeline:select', { entry: getTimelineEntry(id) });
+
+      dragState.id = id;
+      dragState.pointerId = event.pointerId;
+      dragState.hasMoved = false;
+      dragState.startX = getLocalX(event) ?? 0;
+      group.setPointerCapture(event.pointerId);
+    });
+
+    group.addEventListener('pointermove', event => {
+      if (dragState.id !== id || dragState.pointerId !== event.pointerId) {
+        return;
+      }
+
+      const localX = getLocalX(event);
+      if (localX == null) return;
+
+      if (Math.abs(localX - dragState.startX) > 2) {
+        dragState.hasMoved = true;
+      }
+
+      const offset = axisLength ? clamp(localX / axisLength) : 0;
+      updateTimelineEntry(id, { offset });
+    });
+
+    group.addEventListener('pointerup', finishDrag);
+    group.addEventListener('pointercancel', finishDrag);
+  }
+
+  function createMarker(id) {
+    const group = createSvgElement('g', { class: 'djs-timeline-entry', 'data-entry-id': id });
+    const circle = createSvgElement('circle', {
+      cx: 0,
+      cy: 0,
+      r: MARKER_RADIUS,
+      fill: DEFAULT_COLOR,
+      stroke: DEFAULT_STROKE,
+      'stroke-width': '1.5'
+    });
+
+    const label = createSvgElement('text', {
+      x: 0,
+      y: 20,
+      'text-anchor': 'middle',
+      'font-size': '12',
+      fill: '#2d3748'
+    });
+
+    group.appendChild(circle);
+    group.appendChild(label);
+
+    const elements = { group, circle, label };
+    attachMarkerInteraction(elements, id);
+
+    return elements;
+  }
+
+  function requestEdit(id, context = 'select') {
+    const entry = getTimelineEntry(id);
+    if (!entry) return;
+
+    if (typeof onEditEntry === 'function') {
+      onEditEntry(entry, context);
+    }
+
+    dispatchTimelineEvent('timeline:edit', { entry, context });
+  }
+
+  const handleAxisPointerDown = event => {
+    if (event.button !== 0 || event.target !== axis) return;
+    if (!axisLength) return;
+
+    const localX = getLocalX(event);
+    if (localX == null) return;
+
+    const offset = axisLength ? clamp(localX / axisLength) : 0;
+    const entry = addTimelineEntry({ offset });
+    dispatchTimelineEvent('timeline:select', { entry });
+    requestEdit(entry.id, 'create');
+  };
+
+  axis.addEventListener('pointerdown', handleAxisPointerDown);
+
+  const unsubscribeEntries = timelineEntries.subscribe(entries => {
+    renderMarkers(entries);
+    dispatchTimelineEvent('timeline:entriesChanged', { entries });
+  });
+
+  const unsubscribeSelection = selectedTimelineEntryId.subscribe(updateSelection);
+
+  eventBus.on('import.done', updateLayout);
+  eventBus.on('canvas.viewbox.changed', updateLayout);
+  eventBus.on('commandStack.changed', updateLayout);
+
+  updateLayout();
 
   return {
-    update: drawTimeline
+    update: updateLayout,
+    destroy() {
+      unsubscribeEntries?.();
+      unsubscribeSelection?.();
+      axis.removeEventListener('pointerdown', handleAxisPointerDown);
+    }
   };
 }

--- a/public/js/modules/timeline.js
+++ b/public/js/modules/timeline.js
@@ -1,0 +1,89 @@
+import { Stream } from '../core/stream.js';
+
+const clamp = (value, min = 0, max = 1) => Math.min(Math.max(value, min), max);
+
+let idCounter = 0;
+
+function normalizeEntry(partial = {}) {
+  const id = partial.id ?? `timeline-${Date.now()}-${idCounter += 1}`;
+  return {
+    id,
+    offset: clamp(typeof partial.offset === 'number' ? partial.offset : 0),
+    label: partial.label ?? '',
+    metadata: partial.metadata ? { ...partial.metadata } : {},
+    color: partial.color ?? null
+  };
+}
+
+function sortEntries(entries) {
+  return [...entries].sort((a, b) => a.offset - b.offset);
+}
+
+export const timelineEntries = new Stream([]);
+export const selectedTimelineEntryId = new Stream(null);
+
+export function setTimelineEntries(entries) {
+  const normalized = entries.map(normalizeEntry);
+  timelineEntries.set(sortEntries(normalized));
+}
+
+export function addTimelineEntry(entry = {}) {
+  const normalized = normalizeEntry(entry);
+  const next = sortEntries([...timelineEntries.get(), normalized]);
+  timelineEntries.set(next);
+  selectedTimelineEntryId.set(normalized.id);
+  return normalized;
+}
+
+export function updateTimelineEntry(id, updates = {}) {
+  let updatedEntry = null;
+  const next = timelineEntries.get().map(entry => {
+    if (entry.id !== id) {
+      return entry;
+    }
+
+    const nextEntry = {
+      ...entry,
+      ...updates,
+      metadata: updates.metadata
+        ? { ...(entry.metadata ?? {}), ...updates.metadata }
+        : (entry.metadata ? { ...entry.metadata } : {}),
+    };
+
+    if (typeof nextEntry.offset === 'number') {
+      nextEntry.offset = clamp(nextEntry.offset);
+    }
+
+    updatedEntry = nextEntry;
+    return nextEntry;
+  });
+
+  if (!updatedEntry) {
+    return null;
+  }
+
+  const sorted = sortEntries(next);
+  timelineEntries.set(sorted);
+  return updatedEntry;
+}
+
+export function removeTimelineEntry(id) {
+  const filtered = timelineEntries.get().filter(entry => entry.id !== id);
+  timelineEntries.set(filtered);
+  if (selectedTimelineEntryId.get() === id) {
+    selectedTimelineEntryId.set(filtered[0]?.id ?? null);
+  }
+}
+
+export function selectTimelineEntry(id) {
+  selectedTimelineEntryId.set(id ?? null);
+}
+
+export function getTimelineEntry(id) {
+  return timelineEntries.get().find(entry => entry.id === id) ?? null;
+}
+
+export function clearTimelineEntries() {
+  timelineEntries.set([]);
+  selectedTimelineEntryId.set(null);
+}


### PR DESCRIPTION
## Summary
- introduce a reusable timeline stream module for managing waypoint metadata and selection state
- redraw the timeline overlay to use the shared stream, respond to canvas events, and emit custom timeline lifecycle events
- hook the timeline to existing metadata modals so new or selected waypoints can be edited through the existing UI

## Testing
- npm test *(fails: multiple pre-existing simulation assertions and missing sim.* methods)*

------
https://chatgpt.com/codex/tasks/task_e_68cb24cbaa1c8328854453d76821efe8