### PR TITLE
Persist timeline markers via BPMN extensions

### DIFF
--- a/public/js/custom-moddle.json
+++ b/public/js/custom-moddle.json
@@ -34,6 +34,24 @@
         { "name": "consulted",  "type": "String", "isAttr": true },
         { "name": "informed",   "type": "String", "isAttr": true }
       ]
+    },
+    {
+      "name": "Timeline",
+      "superClass": [ "Element" ],
+      "properties": [
+        { "name": "entries", "type": "TimelineEntry", "isMany": true }
+      ]
+    },
+    {
+      "name": "TimelineEntry",
+      "superClass": [ "Element" ],
+      "properties": [
+        { "name": "id", "type": "String", "isAttr": true },
+        { "name": "position", "type": "Double", "isAttr": true },
+        { "name": "label", "type": "String", "isAttr": true },
+        { "name": "color", "type": "String", "isAttr": true },
+        { "name": "metadata", "type": "String" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add custom Timeline and TimelineEntry moddle types for storing timeline metadata
- serialize timeline entries into BPMN process extension elements before saving
- hydrate the timeline stream from BPMN extensions during import so markers rebuild

## Testing
- npm test *(fails: multiple pre-existing simulation and gateway assertions, plus missing simulation helper methods)*

------
https://chatgpt.com/codex/tasks/task_e_68cb271538f483288be16e0cf390fe51