### PR TITLE
Prevent timeline marker pointer events from triggering canvas pan

### DIFF
--- a/public/js/app/timeline.js
+++ b/public/js/app/timeline.js
@@ -213,7 +213,12 @@ export function setupTimeline({ canvas, eventBus, onEditEntry } = {}) {
 
     group.addEventListener('pointerdown', event => {
       if (event.button !== 0) return;
-      event.stopPropagation();
+      event.preventDefault();
+      if (typeof event.stopImmediatePropagation === 'function') {
+        event.stopImmediatePropagation();
+      } else {
+        event.stopPropagation();
+      }
 
       selectTimelineEntry(id);
       dispatchTimelineEvent('timeline:select', { entry: getTimelineEntry(id) });
@@ -243,6 +248,10 @@ export function setupTimeline({ canvas, eventBus, onEditEntry } = {}) {
 
     group.addEventListener('pointerup', finishDrag);
     group.addEventListener('pointercancel', finishDrag);
+
+    group.addEventListener('mousedown', event => {
+      event.preventDefault();
+    });
   }
 
   function createMarker(id) {


### PR DESCRIPTION
## Summary
- call preventDefault/stopImmediatePropagation in timeline marker pointerdown to block diagram-js mouse compatibility events
- add a simple mousedown preventDefault guard on markers to swallow legacy mouse events

## Testing
- npm test *(fails: existing simulation suite assertions and missing methods, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68cb361943a48328b568c6ff7c5c635e