### PR TITLE
Add toolbar control to evenly distribute timeline markers

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -16,7 +16,7 @@ import { doc, collection, updateDoc, setDoc, addDoc, getDoc, Timestamp, arrayUni
 import { setupPageScaffolding, createHiddenFileInput } from './app/init.js';
 import { typeIcons, createOverlay, setupCanvasLayout, attachOverlay } from './app/overlay.js';
 import { setupTimeline } from './app/timeline.js';
-import { timelineEntries, setTimelineEntries, updateTimelineEntry } from './modules/timeline.js';
+import { timelineEntries, setTimelineEntries, updateTimelineEntry, spaceTimelineEntriesEvenly } from './modules/timeline.js';
 import { initializeAddOnServices, setupAvatarMenu } from './app/addons.js';
 import { bootstrapSimulation } from './app/simulation.js';
 import { promptTimelineEntryMetadata } from './timeline/entryModal.js';
@@ -1035,6 +1035,21 @@ function buildDropdownOptions() {
       new Stream('❔'),
       () => window.openHelpGuideModal(),
       { outline: true, title: 'Help guide' }
+    )
+  );
+  controls.push(
+    reactiveButton(
+      new Stream('Timeline'),
+      () => {
+        const spacedEntries = spaceTimelineEntriesEvenly();
+        if (!spacedEntries.length) {
+          showToast('Add timeline entries before using timeline tools.', { type: 'info' });
+          return;
+        }
+
+        showToast('Evenly distributed timeline markers.', { type: 'success' });
+      },
+      { outline: true, title: 'Timeline tools' }
     )
   );
   controls.push(themedThemeSelector());

--- a/public/js/app/timeline.js
+++ b/public/js/app/timeline.js
@@ -310,7 +310,9 @@ export function setupTimeline({ canvas, eventBus, onEditEntry } = {}) {
 
   const unsubscribeEntries = timelineEntries.subscribe(entries => {
     renderMarkers(entries);
-    dispatchTimelineEvent('timeline:entriesChanged', { entries });
+    dispatchTimelineEvent('timeline:entriesChanged', {
+      entries: entries.map(entry => ({ ...entry }))
+    });
   });
 
   const unsubscribeSelection = selectedTimelineEntryId.subscribe(updateSelection);

--- a/public/js/modules/timeline.js
+++ b/public/js/modules/timeline.js
@@ -87,3 +87,18 @@ export function clearTimelineEntries() {
   timelineEntries.set([]);
   selectedTimelineEntryId.set(null);
 }
+
+export function spaceTimelineEntriesEvenly() {
+  const sortedEntries = sortEntries(timelineEntries.get());
+  const count = sortedEntries.length;
+  const denominator = Math.max(count - 1, 1);
+
+  const spacedEntries = sortedEntries.map((entry, index) => ({
+    ...entry,
+    offset: index / denominator
+  }));
+
+  timelineEntries.set(spacedEntries);
+
+  return spacedEntries;
+}


### PR DESCRIPTION
## Summary
- add a helper that evenly spaces timeline entry offsets and writes the update back through the timeline stream
- ensure timeline entry change events dispatch cloned entry data for downstream consumers
- surface a Timeline toolbar button that spaces entries and provides user feedback

## Testing
- `npm test` *(fails: pre-existing BPMN simulation expectations and missing helper APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68cb386f4f208328bfca5e49516e576f