### PR TITLE
Add delete option to timeline entry modal

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -16,7 +16,7 @@ import { doc, collection, updateDoc, setDoc, addDoc, getDoc, Timestamp, arrayUni
 import { setupPageScaffolding, createHiddenFileInput } from './app/init.js';
 import { typeIcons, createOverlay, setupCanvasLayout, attachOverlay } from './app/overlay.js';
 import { setupTimeline } from './app/timeline.js';
-import { timelineEntries, setTimelineEntries, updateTimelineEntry, spaceTimelineEntriesEvenly } from './modules/timeline.js';
+import { timelineEntries, setTimelineEntries, updateTimelineEntry, spaceTimelineEntriesEvenly, removeTimelineEntry } from './modules/timeline.js';
 import { initializeAddOnServices, setupAvatarMenu } from './app/addons.js';
 import { bootstrapSimulation } from './app/simulation.js';
 import { promptTimelineEntryMetadata } from './timeline/entryModal.js';
@@ -141,10 +141,15 @@ setupCanvasLayout({ canvasEl, header, currentTheme });
       const initialLabel = entry.label ?? '';
       const initialNotes = entry.metadata?.notes ?? '';
 
-      promptTimelineEntryMetadata(initialLabel, initialNotes, currentTheme).subscribe(metadata => {
-        if (!metadata) return;
+      promptTimelineEntryMetadata(initialLabel, initialNotes, currentTheme, { allowDelete: true }).subscribe(result => {
+        if (!result) return;
 
-        updateTimelineEntry(entry.id, metadata);
+        if (result.delete) {
+          removeTimelineEntry(entry.id);
+          return;
+        }
+
+        updateTimelineEntry(entry.id, result);
       });
     }
   });

--- a/public/js/timeline/entryModal.js
+++ b/public/js/timeline/entryModal.js
@@ -1,7 +1,12 @@
 import { Stream } from '../core/stream.js';
 import { currentTheme } from '../core/theme.js';
 
-export function promptTimelineEntryMetadata(initialLabel = '', initialNotes = '', themeStream = currentTheme) {
+export function promptTimelineEntryMetadata(
+  initialLabel = '',
+  initialNotes = '',
+  themeStream = currentTheme,
+  { allowDelete = false } = {}
+) {
   const resultStream = new Stream(null);
   const theme = themeStream.get();
   const colors = theme.colors;
@@ -113,6 +118,19 @@ export function promptTimelineEntryMetadata(initialLabel = '', initialNotes = ''
 
   btnRow.appendChild(cancelBtn);
   btnRow.appendChild(saveBtn);
+  if (allowDelete) {
+    const deleteBtn = styledButton('Delete timeline entry', () => {
+      resultStream.set({ delete: true });
+      modal.remove();
+    });
+    const deleteColor = colors.danger || '#c0392b';
+    const deleteHoverColor = colors.dangerHover || '#922b21';
+    deleteBtn.style.backgroundColor = deleteColor;
+    deleteBtn.style.color = colors.background;
+    deleteBtn.onmouseenter = () => deleteBtn.style.backgroundColor = deleteHoverColor;
+    deleteBtn.onmouseleave = () => deleteBtn.style.backgroundColor = deleteColor;
+    btnRow.appendChild(deleteBtn);
+  }
   box.append(title, labelInput, notesInput, btnRow);
   modal.appendChild(box);
   document.body.appendChild(modal);


### PR DESCRIPTION
## Summary
- extend the timeline entry modal to accept options and optionally render a delete button that signals `{ delete: true }`
- update the timeline edit flow to pass the delete option and remove entries when requested

## Testing
- `npm test` *(fails: existing inclusive gateway and simulation boundary event expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3a75d4908328b98677d4964d7604