### PR TITLE
Use icon for timeline spacing control

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1044,7 +1044,7 @@ function buildDropdownOptions() {
   );
   controls.push(
     reactiveButton(
-      new Stream('Timeline'),
+      new Stream('🕒'),
       () => {
         const spacedEntries = spaceTimelineEntriesEvenly();
         if (!spacedEntries.length) {
@@ -1054,7 +1054,7 @@ function buildDropdownOptions() {
 
         showToast('Evenly distributed timeline markers.', { type: 'success' });
       },
-      { outline: true, title: 'Timeline tools' }
+      { outline: true, title: 'Timeline tools', 'aria-label': 'Timeline tools' }
     )
   );
   controls.push(themedThemeSelector());


### PR DESCRIPTION
## Summary
- replace the Timeline toolbar button text with a clock glyph so the control is icon-based
- keep the button hinting intact by providing the existing "Timeline tools" title and aria-label

## Testing
- npm test *(fails: existing workflow simulation assertions and missing simulation helpers)*
- python3 -m http.server 3000 *(manual verification of toolbar icon and tooltip)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3b6547d48328934771e37e571c8f