### PR TITLE
Make timeline colors respond to theme updates

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -137,6 +137,7 @@ setupCanvasLayout({ canvasEl, header, currentTheme });
     canvas,
     eventBus,
     elementRegistry,
+    themeStream: currentTheme,
     onEditEntry(entry) {
       const initialLabel = entry.label ?? '';
       const initialNotes = entry.metadata?.notes ?? '';


### PR DESCRIPTION
## Summary
- update the timeline setup to derive axis, marker, and label colors from the active theme stream and react to updates
- ensure timeline marker rendering respects themed strokes and text colors while reusing fallback hues when theme values are missing
- pass the current theme stream into the timeline bootstrap so theme toggles propagate without reloads

## Testing
- npm test *(fails: several pre-existing simulation assertions and theme loading failures unrelated to the timeline changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3d663ae083289b0058b9bbf24092