### PR TITLE
Improve BPMN marker contrast across themes

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1174,6 +1174,9 @@ currentTheme.subscribe(theme => {
   const taskStroke = task.stroke ?? shapeStroke;
   const gatewayFill = gateway.fill ?? shapeFill;
   const gatewayStroke = gateway.stroke ?? shapeStroke;
+  const connectionStrokeValue = connection.stroke ?? colors.accent ?? colors.foreground ?? shapeStroke ?? '#000';
+  const markerFillValue = marker.fill ?? marker.accent ?? colors.accent ?? connectionStrokeValue ?? colors.foreground ?? '#000';
+  const markerStrokeValue = marker.stroke ?? marker.outline ?? colors.foreground ?? colors.accent ?? connectionStrokeValue ?? '#000';
 
   bpmnThemeStyle.textContent = `
     /* canvas background */
@@ -1298,12 +1301,12 @@ currentTheme.subscribe(theme => {
     /* ── connections & arrows ───────────────────────────────────────────── */
     .djs-connection .djs-connection-inner,
     .djs-connection .djs-connection-outer {
-      stroke: ${connection.stroke ?? shapeStroke} !important;
+      stroke: ${connectionStrokeValue} !important;
       stroke-width: ${connection.strokeWidth ?? shapeStrokeWidth}px !important;
     }
     .djs-connection .djs-marker {
-      fill: ${marker.fill ?? connection.stroke ?? shapeStroke} !important;
-      stroke: ${marker.stroke ?? connection.stroke ?? shapeStroke} !important;
+      fill: ${markerFillValue} !important;
+      stroke: ${markerStrokeValue} !important;
     }
 
     /* ── selected styles ───────────────────────────────────────────────── */

--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -24,8 +24,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#d1b6ff",
-        "stroke": "#d1b6ff"
+        "fill": "#f2e7ff",
+        "stroke": "#bb86fc"
       },
       "label": {
         "fontFamily": "system-ui, sans-serif",
@@ -136,8 +136,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#222222",
-        "stroke": "#222222"
+        "fill": "#6200ee",
+        "stroke": "#3700b3"
       },
       "label": {
         "fontFamily": "system-ui, sans-serif",
@@ -248,8 +248,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#64ffda",
-        "stroke": "#64ffda"
+        "fill": "#00c9a7",
+        "stroke": "#e0fff9"
       },
       "label": {
         "fontFamily": "Roboto, sans-serif",
@@ -360,8 +360,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#64ffda",
-        "stroke": "#64ffda"
+        "fill": "#2aa198",
+        "stroke": "#b2fff3"
       },
       "label": {
         "fontFamily": "Arial, sans-serif",
@@ -472,8 +472,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#657b83",
-        "stroke": "#657b83"
+        "fill": "#268bd2",
+        "stroke": "#1d6ea5"
       },
       "label": {
         "fontFamily": "Georgia, serif",
@@ -584,8 +584,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#64ffda",
-        "stroke": "#64ffda"
+        "fill": "#c8ffef",
+        "stroke": "#2de2b7"
       },
       "label": {
         "fontFamily": "Verdana, sans-serif",
@@ -696,7 +696,7 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#ff7847",
+        "fill": "#ffd1c2",
         "stroke": "#ff7847"
       },
       "label": {
@@ -808,8 +808,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#6b006b",
-        "stroke": "#6b006b"
+        "fill": "#ff69b4",
+        "stroke": "#b3007d"
       },
       "label": {
         "fontFamily": "Comic Sans MS, cursive",
@@ -920,8 +920,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#64ffda",
-        "stroke": "#64ffda"
+        "fill": "#1de9b6",
+        "stroke": "#e0fff9"
       },
       "label": {
         "fontFamily": "Helvetica Neue, sans-serif",
@@ -1032,8 +1032,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#2d2d2a",
-        "stroke": "#2d2d2a"
+        "fill": "#9bc1bc",
+        "stroke": "#4a6d69"
       },
       "label": {
         "fontFamily": "\"Courier Prime\", monospace",
@@ -1144,8 +1144,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#00bfa5",
-        "stroke": "#00bfa5"
+        "fill": "#00ff00",
+        "stroke": "#003300"
       },
       "label": {
         "fontFamily": "\"Share Tech Mono\", monospace",


### PR DESCRIPTION
## Summary
- update all built-in theme marker colors to use higher-contrast fills and strokes so arrowheads stand out from their connectors
- expand the BPMN theming CSS to favor accent-based fallbacks for marker styling while maintaining compatibility with older themes

## Testing
- npm test *(fails: several pre-existing simulation assertions and a theme fetch failure in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d704f4003083288d0afdb17ce35512