### PR TITLE
Adjust BPMN marker contrast in dark themes

### DIFF
--- a/public/js/core/themes.json
+++ b/public/js/core/themes.json
@@ -24,8 +24,8 @@
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#f2e7ff",
-        "stroke": "#bb86fc"
+        "fill": "#f9f2ff",
+        "stroke": "#e6d4ff"
       },
       "label": {
         "fontFamily": "system-ui, sans-serif",
@@ -916,12 +916,12 @@
         "strokeWidth": 2
       },
       "connection": {
-        "stroke": "#64ffda",
+        "stroke": "#36d9b7",
         "strokeWidth": 2
       },
       "marker": {
-        "fill": "#1de9b6",
-        "stroke": "#e0fff9"
+        "fill": "#b2fff2",
+        "stroke": "#e8fffb"
       },
       "label": {
         "fontFamily": "Helvetica Neue, sans-serif",


### PR DESCRIPTION
## Summary
- lighten the BPMN marker fill/stroke colors in the Dark theme to create brighter arrowheads
- adjust Midnight theme connector and marker hues so arrowheads remain pastel and distinct from the lines

## Testing
- npm run start *(fails: Missing script "start")*

------
https://chatgpt.com/codex/tasks/task_e_68d70817626883289f74db3a41554a3d