### PR TITLE
Apply initial theme before toolbar renders

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -121,6 +121,10 @@ function ensureShellLayout() {
   const { canvasEl, header } = setupPageScaffolding({ currentTheme });
   setupCanvasLayout({ canvasEl, header, currentTheme });
 
+  // Ensure the page variables match the initial theme before any controls render
+  // to avoid a flash of unthemed toolbar icons on load.
+  applyThemeToPage(currentTheme.get());
+
   if (!canvasEl.style.position) {
     canvasEl.style.position = 'relative';
   }


### PR DESCRIPTION
## Summary
- apply the current theme to the page as soon as the shell layout is created to avoid the toolbar flashing unthemed styles on load

## Testing
- npm test *(fails: multiple pre-existing assertions and jsdom limitations; see logs for details)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695727907a148328ba57ac4b8bbff879)